### PR TITLE
Fix bug in national model (single geo) for Meridian adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] ; 2025-07-15
+
+### Fixed
+
+- Minor bugs in Meridian adapter supporting national model
+
 ## [0.7.0] ; 2025-07-10
 
 ### Changed

--- a/mmm_eval/_version.py
+++ b/mmm_eval/_version.py
@@ -10,19 +10,19 @@ def _get_version_from_pyproject() -> str:
     current_dir = Path(__file__).parent
     # Go up one level to find pyproject.toml
     pyproject_path = current_dir.parent / "pyproject.toml"
-    
+
     if not pyproject_path.exists():
         raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
-    
+
     with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)
-    
+
     # Extract version from poetry section
     if "tool" in data and "poetry" in data["tool"]:
         version = data["tool"]["poetry"].get("version")
         if version:
             return version
-    
+
     raise ValueError("Version not found in pyproject.toml")
 
 
@@ -33,5 +33,7 @@ except (FileNotFoundError, ValueError) as e:
     # Fallback version if pyproject.toml cannot be read
     __version__ = "0.0.0"
     import warnings
-    warnings.warn(f"Could not read version from pyproject.toml: {e}. Using fallback version {__version__}",
-                  stacklevel=2) 
+
+    warnings.warn(
+        f"Could not read version from pyproject.toml: {e}. Using fallback version {__version__}", stacklevel=2
+    )

--- a/mmm_eval/_version.py
+++ b/mmm_eval/_version.py
@@ -10,19 +10,19 @@ def _get_version_from_pyproject() -> str:
     current_dir = Path(__file__).parent
     # Go up one level to find pyproject.toml
     pyproject_path = current_dir.parent / "pyproject.toml"
-
+    
     if not pyproject_path.exists():
         raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
-
+    
     with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)
-
+    
     # Extract version from poetry section
     if "tool" in data and "poetry" in data["tool"]:
         version = data["tool"]["poetry"].get("version")
         if version:
             return version
-
+    
     raise ValueError("Version not found in pyproject.toml")
 
 
@@ -33,7 +33,5 @@ except (FileNotFoundError, ValueError) as e:
     # Fallback version if pyproject.toml cannot be read
     __version__ = "0.0.0"
     import warnings
-
-    warnings.warn(
-        f"Could not read version from pyproject.toml: {e}. Using fallback version {__version__}", stacklevel=2
-    )
+    warnings.warn(f"Could not read version from pyproject.toml: {e}. Using fallback version {__version__}",
+                  stacklevel=2) 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -350,9 +350,13 @@ class MeridianAdapter(BaseAdapter):
         if self.max_train_date:
             self.holdout_mask = construct_holdout_mask(self.max_train_date, self.training_data.kpi.time)
             # model expects a 2D array of shape (n_geos, n_times) so have to duplicate the values across each geo
-            model_spec_kwargs["holdout_id"] = np.repeat(
+            holdout_id = np.repeat(
                 self.holdout_mask[None, :], repeats=len(self.training_data.kpi.geo), axis=0
             )
+            # if only a single geo, convert to 1D array
+            if holdout_id.shape[0] == 1:
+                holdout_id = holdout_id[0, :]
+            model_spec_kwargs["holdout_id"] = holdout_id
 
         # Create and fit the Meridian model
         model_spec = ModelSpec(**model_spec_kwargs)
@@ -390,7 +394,8 @@ class MeridianAdapter(BaseAdapter):
             raise RuntimeError("Model must be fit before prediction")
 
         # shape (n_chains, n_draws, n_times)
-        preds_tensor = self.analyzer.expected_outcome(aggregate_geos=True, aggregate_times=False)
+        preds_tensor = self.analyzer.expected_outcome(aggregate_geos=True, aggregate_times=False,
+                                                      use_kpi=True)
         posterior_mean = np.mean(preds_tensor, axis=(0, 1))
 
         # if holdout mask is provided, use it to mask the predictions to restrict only to the

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -350,9 +350,7 @@ class MeridianAdapter(BaseAdapter):
         if self.max_train_date:
             self.holdout_mask = construct_holdout_mask(self.max_train_date, self.training_data.kpi.time)
             # model expects a 2D array of shape (n_geos, n_times) so have to duplicate the values across each geo
-            holdout_id = np.repeat(
-                self.holdout_mask[None, :], repeats=len(self.training_data.kpi.geo), axis=0
-            )
+            holdout_id = np.repeat(self.holdout_mask[None, :], repeats=len(self.training_data.kpi.geo), axis=0)
             # if only a single geo, convert to 1D array
             if holdout_id.shape[0] == 1:
                 holdout_id = holdout_id[0, :]
@@ -394,8 +392,7 @@ class MeridianAdapter(BaseAdapter):
             raise RuntimeError("Model must be fit before prediction")
 
         # shape (n_chains, n_draws, n_times)
-        preds_tensor = self.analyzer.expected_outcome(aggregate_geos=True, aggregate_times=False,
-                                                      use_kpi=True)
+        preds_tensor = self.analyzer.expected_outcome(aggregate_geos=True, aggregate_times=False, use_kpi=True)
         posterior_mean = np.mean(preds_tensor, axis=(0, 1))
 
         # if holdout mask is provided, use it to mask the predictions to restrict only to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mmm-eval"
-version = "0.7.0"
+version = "0.7.1"
 description = "Open-source evaluation of marketing mix model (MMM) performance"
 authors = ["Joseph Kang <joseph.kang@mutinex.co>",
            "Phil Clark <phil.clark@mutinex.co>",


### PR DESCRIPTION
The `holdout_id` argument needs to be a 1D array when the data passed has only a single geo (national).

Also ensures that the model returns predictions in terms of the KPI, not revenue.