### PR TITLE
Add SMAPE as default accuracy metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] ; 2025-07-17
+
+### Added
+
+- SMAPE metric to accuracy and CV accuracy tests
+
+### Changed
+
+- All metrics with "percentage" in the name to be actual percentages, e.g. 15 instead of 0.15
+
 ## [0.8.0] ; 2025-07-17
 
 ### Changed

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -139,11 +139,28 @@ def calculate_mape(actual: List[float], predicted: List[float]) -> float:
         
     Returns:
         MAPE value as a float
-        
-    Raises:
-        ValueError: If inputs are empty or have different lengths
     """
-    pass
+    if len(actual) != len(predicted):
+        raise ValueError("Actual and predicted lists must have same length")
+    
+    errors = [abs((a - p) / a) for a, p in zip(actual, predicted) if a != 0]
+    return sum(errors) / len(errors) if errors else 0.0
+
+def calculate_smape(actual: List[float], predicted: List[float]) -> float:
+    """Calculate Symmetric Mean Absolute Percentage Error.
+    
+    Args:
+        actual: List of actual values
+        predicted: List of predicted values
+        
+    Returns:
+        SMAPE value as a float
+    """
+    if len(actual) != len(predicted):
+        raise ValueError("Actual and predicted lists must have same length")
+    
+    errors = [2 * abs(a - p) / (abs(a) + abs(p)) for a, p in zip(actual, predicted) if abs(a) + abs(p) != 0]
+    return sum(errors) / len(errors) if errors else 0.0
 ```
 
 ## Testing
@@ -175,7 +192,7 @@ Example test:
 
 ```python
 import pytest
-from mmm_eval.metrics import calculate_mape
+from mmm_eval.metrics import calculate_mape, calculate_smape
 
 def test_calculate_mape_basic():
     """Test basic MAPE calculation."""
@@ -187,10 +204,25 @@ def test_calculate_mape_basic():
     assert isinstance(mape, float)
     assert mape > 0
 
+def test_calculate_smape_basic():
+    """Test basic SMAPE calculation."""
+    actual = [100, 200, 300]
+    predicted = [110, 190, 310]
+    
+    smape = calculate_smape(actual, predicted)
+    
+    assert isinstance(smape, float)
+    assert smape > 0
+
 def test_calculate_mape_empty_input():
     """Test MAPE calculation with empty input."""
     with pytest.raises(ValueError):
         calculate_mape([], [])
+
+def test_calculate_smape_empty_input():
+    """Test SMAPE calculation with empty input."""
+    with pytest.raises(ValueError):
+        calculate_smape([], [])
 ```
 
 ## Documentation

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -140,27 +140,7 @@ def calculate_mape(actual: List[float], predicted: List[float]) -> float:
     Returns:
         MAPE value as a float
     """
-    if len(actual) != len(predicted):
-        raise ValueError("Actual and predicted lists must have same length")
-    
-    errors = [abs((a - p) / a) for a, p in zip(actual, predicted) if a != 0]
-    return sum(errors) / len(errors) if errors else 0.0
-
-def calculate_smape(actual: List[float], predicted: List[float]) -> float:
-    """Calculate Symmetric Mean Absolute Percentage Error.
-    
-    Args:
-        actual: List of actual values
-        predicted: List of predicted values
-        
-    Returns:
-        SMAPE value as a float
-    """
-    if len(actual) != len(predicted):
-        raise ValueError("Actual and predicted lists must have same length")
-    
-    errors = [2 * abs(a - p) / (abs(a) + abs(p)) for a, p in zip(actual, predicted) if abs(a) + abs(p) != 0]
-    return sum(errors) / len(errors) if errors else 0.0
+    pass
 ```
 
 ## Testing

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -184,25 +184,10 @@ def test_calculate_mape_basic():
     assert isinstance(mape, float)
     assert mape > 0
 
-def test_calculate_smape_basic():
-    """Test basic SMAPE calculation."""
-    actual = [100, 200, 300]
-    predicted = [110, 190, 310]
-    
-    smape = calculate_smape(actual, predicted)
-    
-    assert isinstance(smape, float)
-    assert smape > 0
-
 def test_calculate_mape_empty_input():
     """Test MAPE calculation with empty input."""
     with pytest.raises(ValueError):
         calculate_mape([], [])
-
-def test_calculate_smape_empty_input():
-    """Test SMAPE calculation with empty input."""
-    with pytest.raises(ValueError):
-        calculate_smape([], [])
 ```
 
 ## Documentation

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -172,7 +172,7 @@ Example test:
 
 ```python
 import pytest
-from mmm_eval.metrics import calculate_mape, calculate_smape
+from mmm_eval.metrics import calculate_mape
 
 def test_calculate_mape_basic():
     """Test basic MAPE calculation."""

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -93,7 +93,8 @@ def test_calculate_mape_returns_correct_value():
     
     result = calculate_mape(actual, predicted)
     
-    assert result == pytest.approx(0.1, rel=1e-2)
+    expected = 10.0 # 10% average error
+    assert result == pytest.approx(expected, rel=1e-2)
 ```
 
 ### Integration Tests
@@ -248,15 +249,6 @@ def test_mape_calculation_performance(benchmark):
     predicted = [110, 190, 310] * 1000
     
     result = benchmark(lambda: calculate_mape(actual, predicted))
-    
-    assert result > 0
-
-def test_smape_calculation_performance(benchmark):
-    """Benchmark SMAPE calculation performance."""
-    actual = [100, 200, 300] * 1000
-    predicted = [110, 190, 310] * 1000
-    
-    result = benchmark(lambda: calculate_smape(actual, predicted))
     
     assert result > 0
 ```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -93,8 +93,16 @@ def test_calculate_mape_returns_correct_value():
     
     result = calculate_mape(actual, predicted)
     
-    expected = 10.0  # 10% average error
-    assert result == pytest.approx(expected, rel=1e-2)
+    assert result == pytest.approx(0.1, rel=1e-2)
+
+def test_calculate_smape_returns_correct_value():
+    """Test that SMAPE calculation returns expected results."""
+    actual = [100, 200, 300]
+    predicted = [110, 190, 310]
+    
+    result = calculate_smape(actual, predicted)
+    
+    assert result == pytest.approx(0.095, rel=1e-2)
 ```
 
 ### Integration Tests
@@ -245,176 +253,19 @@ For performance-critical code, use benchmark tests:
 ```python
 def test_mape_calculation_performance(benchmark):
     """Benchmark MAPE calculation performance."""
-    actual = np.random.normal(1000, 100, 10000)
-    predicted = np.random.normal(1000, 100, 10000)
+    actual = [100, 200, 300] * 1000
+    predicted = [110, 190, 310] * 1000
     
     result = benchmark(lambda: calculate_mape(actual, predicted))
     
     assert result > 0
-```
 
-### Memory Usage Tests
-
-Monitor memory usage in tests:
-
-```python
-import psutil
-import os
-
-def test_memory_usage():
-    """Test that operations don't use excessive memory."""
-    process = psutil.Process(os.getpid())
-    initial_memory = process.memory_info().rss
+def test_smape_calculation_performance(benchmark):
+    """Benchmark SMAPE calculation performance."""
+    actual = [100, 200, 300] * 1000
+    predicted = [110, 190, 310] * 1000
     
-    # Run memory-intensive operation
-    result = process_large_dataset()
+    result = benchmark(lambda: calculate_smape(actual, predicted))
     
-    final_memory = process.memory_info().rss
-    memory_increase = final_memory - initial_memory
-    
-    # Memory increase should be reasonable (< 100MB)
-    assert memory_increase < 100 * 1024 * 1024
-```
-
-## Continuous Integration
-
-### GitHub Actions
-
-Tests run automatically on:
-
-- Every pull request
-- Every push to main branch
-- Scheduled runs (nightly)
-
-### CI Configuration
-
-The CI pipeline includes:
-
-1. **Linting**: Code style and quality checks
-2. **Type checking**: Static type analysis
-3. **Unit tests**: Fast feedback on basic functionality
-4. **Integration tests**: Verify component interactions
-5. **Coverage reporting**: Track test coverage trends
-
-### Pre-commit Hooks
-
-Install pre-commit hooks to catch issues early:
-
-```bash
-# Install pre-commit
-poetry add --group dev pre-commit
-
-# Install hooks
-pre-commit install
-
-# Run all hooks
-pre-commit run --all-files
-```
-
-## Debugging Tests
-
-### Verbose Output
-
-```bash
-# Run with maximum verbosity
-poetry run pytest -vvv
-
-# Show local variables on failures
-poetry run pytest -l
-
-# Stop on first failure
-poetry run pytest -x
-```
-
-### Debugging with pdb
-
-```python
-def test_debug_example():
-    """Example of using pdb for debugging."""
-    import pdb; pdb.set_trace()  # Breakpoint
-    result = complex_calculation()
     assert result > 0
 ```
-
-### Test Isolation
-
-Ensure tests don't interfere with each other:
-
-```python
-@pytest.fixture(autouse=True)
-def reset_global_state():
-    """Reset global state before each test."""
-    # Setup
-    yield
-    # Teardown
-    cleanup_global_state()
-```
-
-## Best Practices
-
-### Test Naming
-
-- Use descriptive test names that explain the expected behavior
-- Follow the pattern: `test_[function]_[scenario]_[expected_result]`
-- Include edge cases and error conditions
-
-### Test Organization
-
-- Group related tests in classes
-- Use fixtures for common setup
-- Keep tests focused and single-purpose
-
-### Assertions
-
-- Use specific assertions (`assert result == expected`)
-- Avoid complex logic in assertions
-- Use appropriate assertion methods (`assertIn`, `assertRaises`, etc.)
-
-### Test Data
-
-- Use realistic test data
-- Avoid hardcoded magic numbers
-- Document test data assumptions
-
-### Documentation
-
-- Write clear docstrings for test functions
-- Explain complex test scenarios
-- Document test data sources and assumptions
-
-## Common Pitfalls
-
-### Flaky Tests
-
-Avoid flaky tests by:
-
-- Not relying on timing or external services
-- Using deterministic random seeds
-- Properly mocking external dependencies
-- Avoiding shared state between tests
-
-### Slow Tests
-
-Keep tests fast by:
-
-- Using appropriate mocks
-- Minimizing I/O operations
-- Using efficient test data
-- Running tests in parallel when possible
-
-### Over-Mocking
-
-Don't over-mock:
-
-- Test the actual behavior, not the implementation
-- Mock only external dependencies
-- Use real objects when possible
-
-## Getting Help
-
-If you encounter testing issues:
-
-1. Check the [pytest documentation](https://docs.pytest.org/)
-2. Review existing tests for examples
-3. Ask questions in project discussions
-4. Consult the [Contributing Guide](contributing.md) 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -94,15 +94,6 @@ def test_calculate_mape_returns_correct_value():
     result = calculate_mape(actual, predicted)
     
     assert result == pytest.approx(0.1, rel=1e-2)
-
-def test_calculate_smape_returns_correct_value():
-    """Test that SMAPE calculation returns expected results."""
-    actual = [100, 200, 300]
-    predicted = [110, 190, 310]
-    
-    result = calculate_smape(actual, predicted)
-    
-    assert result == pytest.approx(0.095, rel=1e-2)
 ```
 
 ### Integration Tests
@@ -269,3 +260,111 @@ def test_smape_calculation_performance(benchmark):
     
     assert result > 0
 ```
+
+## Debugging Tests
+
+### Verbose Output
+
+```bash
+# Run with maximum verbosity
+poetry run pytest -vvv
+
+# Show local variables on failures
+poetry run pytest -l
+
+# Stop on first failure
+poetry run pytest -x
+```
+
+### Debugging with pdb
+
+```python
+def test_debug_example():
+    """Example of using pdb for debugging."""
+    import pdb; pdb.set_trace()  # Breakpoint
+    result = complex_calculation()
+    assert result > 0
+```
+
+### Test Isolation
+
+Ensure tests don't interfere with each other:
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    """Reset global state before each test."""
+    # Setup
+    yield
+    # Teardown
+    cleanup_global_state()
+```
+
+## Best Practices
+
+### Test Naming
+
+- Use descriptive test names that explain the expected behavior
+- Follow the pattern: `test_[function]_[scenario]_[expected_result]`
+- Include edge cases and error conditions
+
+### Test Organization
+
+- Group related tests in classes
+- Use fixtures for common setup
+- Keep tests focused and single-purpose
+
+### Assertions
+
+- Use specific assertions (`assert result == expected`)
+- Avoid complex logic in assertions
+- Use appropriate assertion methods (`assertIn`, `assertRaises`, etc.)
+
+### Test Data
+
+- Use realistic test data
+- Avoid hardcoded magic numbers
+- Document test data assumptions
+
+### Documentation
+
+- Write clear docstrings for test functions
+- Explain complex test scenarios
+- Document test data sources and assumptions
+
+## Common Pitfalls
+
+### Flaky Tests
+
+Avoid flaky tests by:
+
+- Not relying on timing or external services
+- Using deterministic random seeds
+- Properly mocking external dependencies
+- Avoiding shared state between tests
+
+### Slow Tests
+
+Keep tests fast by:
+
+- Using appropriate mocks
+- Minimizing I/O operations
+- Using efficient test data
+- Running tests in parallel when possible
+
+### Over-Mocking
+
+Don't over-mock:
+
+- Test the actual behavior, not the implementation
+- Mock only external dependencies
+- Use real objects when possible
+
+## Getting Help
+
+If you encounter testing issues:
+
+1. Check the [pytest documentation](https://docs.pytest.org/)
+2. Review existing tests for examples
+3. Ask questions in project discussions
+4. Consult the [Contributing Guide](contributing.md) 

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -171,8 +171,10 @@ results/
 ```csv
 test_name,metric_name,metric_value,metric_pass
 accuracy,mape,15.0,True
+accuracy,smape,14.5,True
 accuracy,r_squared,0.85,True
 cross_validation,mape,18.0,True
+cross_validation,smape,17.5,True
 cross_validation,r_squared,0.82,True
 refresh_stability,mean_percentage_change_for_each_channel:channel_1,5.0,True
 refresh_stability,mean_percentage_change_for_each_channel:channel_2,3.0,True

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -174,12 +174,12 @@ accuracy,mape,15.0,True
 accuracy,r_squared,0.85,True
 cross_validation,mape,18.0,True
 cross_validation,r_squared,0.82,True
-refresh_stability,mean_percentage_change_for_each_channel:channel_1,0.05,True
-refresh_stability,mean_percentage_change_for_each_channel:channel_2,0.03,True
-refresh_stability,std_percentage_change_for_each_channel:channel_1,0.02,True
-refresh_stability,std_percentage_change_for_each_channel:channel_2,0.01,True
-perturbation,percentage_change_for_each_channel:channel_1,0.02,True
-perturbation,percentage_change_for_each_channel:channel_2,0.01,True
+refresh_stability,mean_percentage_change_for_each_channel:channel_1,5.0,True
+refresh_stability,mean_percentage_change_for_each_channel:channel_2,3.0,True
+refresh_stability,std_percentage_change_for_each_channel:channel_1,2.0,True
+refresh_stability,std_percentage_change_for_each_channel:channel_2,1.0,True
+perturbation,percentage_change_for_each_channel:channel_1,2.0,True
+perturbation,percentage_change_for_each_channel:channel_2,1.0,True
 ```
 
 ## Performance Examples

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -170,9 +170,9 @@ results/
 
 ```csv
 test_name,metric_name,metric_value,metric_pass
-accuracy,mape,0.15,True
+accuracy,mape,15.0,True
 accuracy,r_squared,0.85,True
-cross_validation,mape,0.18,True
+cross_validation,mape,18.0,True
 cross_validation,r_squared,0.82,True
 refresh_stability,mean_percentage_change_for_each_channel:channel_1,0.05,True
 refresh_stability,mean_percentage_change_for_each_channel:channel_2,0.03,True

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -165,10 +165,10 @@ If we look at the evaluation output ```display(results)```, we'll see something 
 
 |     test_name     |                  metric_name                  | metric_value | metric_pass |
 |-------------------|-----------------------------------------------|--------------|-------------|
-| accuracy          | mape                                          | 0.121        | False       |
+| accuracy          | mape                                          | 12.1         | False       |
 | accuracy          | r_squared                                     | -0.547       | False       |
-| cross_validation  | mean_mape                                     | 0.084        | False       |
-| cross_validation  | std_mape                                      | 0.058        | False       |
+| cross_validation  | mean_mape                                     | 8.4          | False       |
+| cross_validation  | std_mape                                      | 5.8          | False       |
 | cross_validation  | mean_r_squared                                | -7.141       | False       |
 | cross_validation  | std_r_squared                                 | 9.686        | False       |
 | refresh_stability | mean_percentage_change_for_each_channel:TV    | 0.021        | False       |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -171,12 +171,12 @@ If we look at the evaluation output ```display(results)```, we'll see something 
 | cross_validation  | std_mape                                      | 5.8          | False       |
 | cross_validation  | mean_r_squared                                | -7.141       | False       |
 | cross_validation  | std_r_squared                                 | 9.686        | False       |
-| refresh_stability | mean_percentage_change_for_each_channel:TV    | 0.021        | False       |
-| refresh_stability | mean_percentage_change_for_each_channel:radio | 0.369        | False       |
-| refresh_stability | std_percentage_change_for_each_channel:TV     | 0.021        | False       |
-| refresh_stability | std_percentage_change_for_each_channel:radio  | 0.397        | False       |
-| perturbation      | percentage_change_for_each_channel:TV         | 0.005        | False       |
-| perturbation      | percentage_change_for_each_channel:radio      | 0.112        | False       |
+| refresh_stability | mean_percentage_change_for_each_channel:TV    | 2.1          | False       |
+| refresh_stability | mean_percentage_change_for_each_channel:radio | 36.9         | False       |
+| refresh_stability | std_percentage_change_for_each_channel:TV     | 2.1          | False       |
+| refresh_stability | std_percentage_change_for_each_channel:radio  | 39.7         | False       |
+| perturbation      | percentage_change_for_each_channel:TV         | 0.5          | False       |
+| perturbation      | percentage_change_for_each_channel:radio      | 11.2         | False       |
 
 
 Notice that our model is failing every test. Seems we have some work to do!

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -157,6 +157,9 @@ Details on the implementation of the tests can be found in [Tests](../user-guide
 * **MAPE (Mean Absolute Percentage Error)**  
   `MAPE = (100 / n) * Σ |(y_i - ŷ_i) / y_i|`
 
+* **SMAPE (Symmetric Mean Absolute Percentage Error)**  
+  `SMAPE = 100 * (2 * |y_i - ŷ_i|) / (|y_i| + |ŷ_i|)`
+
 * **R-squared (Coefficient of Determination)**  
   `R² = 1 - (Σ (y_i - ŷ_i)^2) / (Σ (y_i - ȳ)^2)`
 
@@ -166,9 +169,12 @@ If we look at the evaluation output ```display(results)```, we'll see something 
 |     test_name     |                  metric_name                  | metric_value | metric_pass |
 |-------------------|-----------------------------------------------|--------------|-------------|
 | accuracy          | mape                                          | 12.1         | False       |
+| accuracy          | smape                                         | 11.8         | False       |
 | accuracy          | r_squared                                     | -0.547       | False       |
 | cross_validation  | mean_mape                                     | 8.4          | False       |
 | cross_validation  | std_mape                                      | 5.8          | False       |
+| cross_validation  | mean_smape                                    | 8.1          | False       |
+| cross_validation  | std_smape                                     | 5.5          | False       |
 | cross_validation  | mean_r_squared                                | -7.141       | False       |
 | cross_validation  | std_r_squared                                 | 9.686        | False       |
 | refresh_stability | mean_percentage_change_for_each_channel:TV    | 2.1          | False       |

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ mmm-eval --input-data-path data.csv --config-path config.json --output-path ./ou
 - **Extensible**: Easy to add new frameworks
 
 ### Comprehensive Testing
-- **Accuracy Tests**: MAPE, RMSE, R-squared metrics
+- **Accuracy Tests**: MAPE, SMAPE, R-squared metrics
 - **Cross-Validation**: Time series cross-validation
 - **Refresh Stability**: Model stability over time
 - **Performance Tests**: Computational efficiency metrics

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -42,7 +42,7 @@ MAPE = (1/n) * Σ |(y_i - ŷ_i) / y_i|
 
 **Interpretation**:
 - **Lower is better**: 0% = perfect predictions
-- **Scale**: Expressed as a proportion, e.g. 0.15 rather than 15%
+- **Scale**: Expressed as a percentage, e.g. 15.0 rather than 0.15
 
 ### RMSE (Root Mean Square Error)
 

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -24,13 +24,6 @@ mmm-eval calculates several key metrics across different validation tests:
 - **Channel Stability**: Stability of media channel coefficients
 - **Intercept Stability**: Stability of baseline parameters
 
-### Performance Metrics
-
-- **Training Time**: Time required to fit the model
-- **Memory Usage**: Peak memory consumption during training
-- **Prediction Time**: Time to generate predictions
-- **Convergence**: Number of iterations to reach convergence
-
 ## Metric Definitions
 
 ### MAPE (Mean Absolute Percentage Error)
@@ -54,7 +47,6 @@ SMAPE = 100 * (2 * |y_i - ŷ_i|) / (|y_i| + |ŷ_i|)
 - **Scale**: Expressed as a percentage, e.g. 15.0 rather than 0.15
 - **Symmetric**: Treats over and underestimation equally (unlike MAPE)
 - **Robust**: Less sensitive to extreme values and zero actual values
-- **Range**: 0% to 200% (200% when actual = 0 and predicted ≠ 0)
 
 **Advantages over MAPE**:
 - **Symmetry**: 10% overestimation and 10% underestimation give the same SMAPE value
@@ -95,12 +87,11 @@ R² = 1 - (Σ(y_i - ŷ_i)² / Σ(y_i - ȳ)²)
 - **Std Percentage Change**: Consistency of parameter changes
 - **Channel-specific Stability**: Stability per media channel
 
-### Performance Metrics
+### Perturbation Metrics
 
-- **Training Time**: Time required to fit the model
-- **Memory Usage**: Peak memory consumption during training
-- **Prediction Time**: Time to generate predictions
-- **Convergence**: Number of iterations to reach convergence
+- **Percentage Change**: Change in ROI estimates when input data is perturbed
+- **Channel-specific Sensitivity**: Sensitivity of each media channel to data perturbations
+- **Model Robustness**: Overall model stability to input noise
 
 ## Interpreting Results
 
@@ -110,19 +101,12 @@ R² = 1 - (Σ(y_i - ŷ_i)² / Σ(y_i - ȳ)²)
 - **SMAPE < 15%**: Good symmetric prediction accuracy
 - **R-squared > 0.8**: Strong model fit
 - **Low parameter changes**: Stable model
+- **Low perturbation sensitivity**: Robust to input noise
 - **Reasonable training time**: Efficient computation
-
-### Warning Signs
-
-- **MAPE > 30%**: Poor prediction accuracy
-- **SMAPE > 30%**: Poor symmetric prediction accuracy
-- **R-squared < 0.5**: Weak model fit
-- **High parameter changes**: Unstable model
-- **Excessive training time**: Computational issues
 
 ## Thresholds and Benchmarks
 
-### Industry Benchmarks
+### Rough Benchmarks
 
 | Metric | Excellent | Good | Acceptable | Poor |
 |--------|-----------|------|------------|------|
@@ -130,6 +114,7 @@ R² = 1 - (Σ(y_i - ŷ_i)² / Σ(y_i - ȳ)²)
 | SMAPE | < 5% | 5-10% | 10-15% | > 15% |
 | R-squared | > 0.9 | 0.8-0.9 | 0.6-0.8 | < 0.6 |
 | Parameter Change | < 5% | 5-10% | 10-20% | > 20% |
+| Perturbation Change | < 5% | 5-10% | 10-15% | > 15% |
 
 ## Customizing Metrics
 

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -15,9 +15,8 @@ mmm-eval calculates several key metrics across different validation tests:
 ### Accuracy Metrics
 
 - **MAPE (Mean Absolute Percentage Error)**: Average percentage error between predictions and actual values
-- **RMSE (Root Mean Square Error)**: Standard deviation of prediction errors
+- **SMAPE (Symmetric Mean Absolute Percentage Error)**: Symmetric version of MAPE that treats over and underestimation equally
 - **R-squared**: Proportion of variance explained by the model
-- **MAE (Mean Absolute Error)**: Average absolute prediction error
 
 ### Stability Metrics
 
@@ -44,16 +43,23 @@ MAPE = (1/n) * Σ |(y_i - ŷ_i) / y_i|
 - **Lower is better**: 0% = perfect predictions
 - **Scale**: Expressed as a percentage, e.g. 15.0 rather than 0.15
 
-### RMSE (Root Mean Square Error)
+### SMAPE (Symmetric Mean Absolute Percentage Error)
 
 ```python
-RMSE = √(Σ(y_i - ŷ_i)² / n)
+SMAPE = 100 * (2 * |y_i - ŷ_i|) / (|y_i| + |ŷ_i|)
 ```
 
 **Interpretation**:
-- **Lower is better**: 0 = perfect predictions
-- **Units**: Same as target variable
-- **Sensitivity**: More sensitive to large errors than MAPE
+- **Lower is better**: 0% = perfect predictions
+- **Scale**: Expressed as a percentage, e.g. 15.0 rather than 0.15
+- **Symmetric**: Treats over and underestimation equally (unlike MAPE)
+- **Robust**: Less sensitive to extreme values and zero actual values
+- **Range**: 0% to 200% (200% when actual = 0 and predicted ≠ 0)
+
+**Advantages over MAPE**:
+- **Symmetry**: 10% overestimation and 10% underestimation give the same SMAPE value
+- **Zero handling**: Better handling of zero or near-zero actual values
+- **Bounded**: Upper bound of 200% vs. unbounded MAPE
 
 ### R-squared (Coefficient of Determination)
 
@@ -66,30 +72,20 @@ R² = 1 - (Σ(y_i - ŷ_i)² / Σ(y_i - ȳ)²)
 - **Scale**: 1 = perfect fit, 0 = no predictive power
 - **Benchmark**: > 0.8 is generally good
 
-### MAE (Mean Absolute Error)
-
-```python
-MAE = (1/n) * Σ |y_i - ŷ_i|
-```
-
-**Interpretation**:
-- **Lower is better**: 0 = perfect predictions
-- **Units**: Same as target variable
-- **Robustness**: Less sensitive to outliers than RMSE
-
 ## Test-Specific Metrics
 
 ### Accuracy Test Metrics
 
 - **MAPE**: Overall prediction accuracy
-- **RMSE**: Error magnitude
+- **SMAPE**: Symmetric prediction accuracy
 - **R-squared**: Model fit quality
-- **MAE**: Absolute error magnitude
 
 ### Cross-Validation Metrics
 
 - **Mean MAPE**: Average out-of-sample accuracy
 - **Std MAPE**: Consistency of accuracy across folds
+- **Mean SMAPE**: Average out-of-sample symmetric accuracy
+- **Std SMAPE**: Consistency of symmetric accuracy across folds
 - **Mean R-squared**: Average out-of-sample fit
 - **Std R-squared**: Consistency of fit across folds
 
@@ -101,16 +97,17 @@ MAE = (1/n) * Σ |y_i - ŷ_i|
 
 ### Performance Metrics
 
-- **Training Time**: Model fitting efficiency
-- **Memory Usage**: Resource utilization
-- **Prediction Time**: Inference speed
-- **Convergence Iterations**: Optimization efficiency
+- **Training Time**: Time required to fit the model
+- **Memory Usage**: Peak memory consumption during training
+- **Prediction Time**: Time to generate predictions
+- **Convergence**: Number of iterations to reach convergence
 
 ## Interpreting Results
 
 ### Good Performance Indicators
 
 - **MAPE < 15%**: Good prediction accuracy
+- **SMAPE < 15%**: Good symmetric prediction accuracy
 - **R-squared > 0.8**: Strong model fit
 - **Low parameter changes**: Stable model
 - **Reasonable training time**: Efficient computation
@@ -118,6 +115,7 @@ MAE = (1/n) * Σ |y_i - ŷ_i|
 ### Warning Signs
 
 - **MAPE > 30%**: Poor prediction accuracy
+- **SMAPE > 30%**: Poor symmetric prediction accuracy
 - **R-squared < 0.5**: Weak model fit
 - **High parameter changes**: Unstable model
 - **Excessive training time**: Computational issues
@@ -129,6 +127,7 @@ MAE = (1/n) * Σ |y_i - ŷ_i|
 | Metric | Excellent | Good | Acceptable | Poor |
 |--------|-----------|------|------------|------|
 | MAPE | < 5% | 5-10% | 10-15% | > 15% |
+| SMAPE | < 5% | 5-10% | 10-15% | > 15% |
 | R-squared | > 0.9 | 0.8-0.9 | 0.6-0.8 | < 0.6 |
 | Parameter Change | < 5% | 5-10% | 10-20% | > 20% |
 
@@ -157,6 +156,7 @@ class CustomMetric(BaseMetric):
 ### Metric Selection
 
 - **Start with MAPE**: Most intuitive for business users
+- **Include SMAPE**: More robust alternative to MAPE for symmetric evaluation
 - **Include R-squared**: Technical measure of fit quality
 - **Monitor stability**: Critical for production models
 - **Track performance**: Important for scalability
@@ -173,9 +173,10 @@ class CustomMetric(BaseMetric):
 ### Common Issues
 
 1. **Extreme MAPE values**: Check for zero or near-zero actual values
-2. **Negative R-squared**: Model performs worse than baseline
-3. **Inconsistent metrics**: Verify data preprocessing
-4. **Missing metrics**: Check test configuration
+2. **High SMAPE values**: Check for symmetric errors and zero handling
+3. **Negative R-squared**: Model performs worse than baseline
+4. **Inconsistent metrics**: Verify data preprocessing
+5. **Missing metrics**: Check test configuration
 
 ### Getting Help
 

--- a/docs/user-guide/tests.md
+++ b/docs/user-guide/tests.md
@@ -18,13 +18,13 @@ Accuracy tests evaluate how well the model fits the training data.
 ### Metrics
 
 - **MAPE (Mean Absolute Percentage Error)**: Average percentage error
-- **RMSE (Root Mean Square Error)**: Standard deviation of prediction errors
+- **SMAPE (Symmetric Mean Absolute Percentage Error)**: Symmetric version of MAPE
 - **R-squared**: Proportion of variance explained by the model
-- **MAE (Mean Absolute Error)**: Average absolute prediction error
 
 ### Interpretation
 
-- **Lower MAPE/RMSE/MAE**: Better model performance
+- **Lower MAPE**: Better model performance
+- **Lower SMAPE**: Better symmetric model performance
 - **Higher R-squared**: Better model fit (0-1 scale)
 
 ## Cross-Validation Tests
@@ -41,9 +41,8 @@ Cross-validation tests assess how well the model generalizes to unseen data.
 ### Metrics
 
 - **MAPE**: Out-of-sample prediction accuracy
-- **RMSE**: Out-of-sample error magnitude
+- **SMAPE**: Out-of-sample symmetric prediction accuracy
 - **R-squared**: Out-of-sample explanatory power
-- **MAE**: Out-of-sample absolute error
 
 ### Interpretation
 
@@ -123,17 +122,17 @@ modify the thresholds in `mmm_eval/metrics/threshold_constants.py`.
 
 ### Good Model Indicators
 
-- **Accuracy**: MAPE < 15%, R-squared > 0.8
-- **Cross-Validation**: Out-of-sample MAPE similar to in-sample
-- **Stability**: Parameter changes < 10%
-- **Performance**: Reasonable training times
+- **Accuracy**: MAPE < 15%, SMAPE < 15%, R-squared > 0.8
+- **Cross-Validation**: Out-of-sample MAPE/SMAPE similar to in-sample
+- **Refresh Stability**: Parameter changes < 10%
+- **Perturbation**: ROI changes < 5%
 
 ### Warning Signs
 
-- **Overfitting**: Much better in-sample than out-of-sample performance
-- **Instability**: Large parameter changes with new data
-- **Poor Performance**: High MAPE or low R-squared
-- **Slow Training**: Excessive computation time
+- **Poor Performance**: High MAPE/SMAPE or low R-squared
+- **Unstable Model**: Large parameter changes
+- **Overfitting**: In-sample vs out-of-sample performance gap
+- **Data Issues**: Missing values or extreme outliers
 
 ## Best Practices
 

--- a/mmm_eval/core/constants.py
+++ b/mmm_eval/core/constants.py
@@ -6,7 +6,7 @@ class ValidationTestConstants:
 
     TRAIN_TEST_SPLIT_TEST_PROPORTION = 0.2
     RANDOM_STATE = 42
-    N_SPLITS = 5
+    N_SPLITS = 2
     TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4  # 4 representing a 4 week refresh
 
     class PerturbationConstants:

--- a/mmm_eval/core/constants.py
+++ b/mmm_eval/core/constants.py
@@ -6,8 +6,8 @@ class ValidationTestConstants:
 
     TRAIN_TEST_SPLIT_TEST_PROPORTION = 0.2
     RANDOM_STATE = 42
-    N_SPLITS = 2
-    TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4  # 4 representing a 4 week refresh
+    N_SPLITS = 5
+    TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4
 
     class PerturbationConstants:
         """Constants for the perturbation test."""

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -17,7 +17,6 @@ from mmm_eval.metrics.accuracy_functions import (
     calculate_means_for_series_across_cross_validation_folds,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
-    calculate_smape,
 )
 from mmm_eval.metrics.metric_models import (
     AccuracyMetricNames,

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -17,6 +17,7 @@ from mmm_eval.metrics.accuracy_functions import (
     calculate_means_for_series_across_cross_validation_folds,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
+    calculate_smape,
 )
 from mmm_eval.metrics.metric_models import (
     AccuracyMetricNames,
@@ -122,6 +123,12 @@ class CrossValidationTest(BaseValidationTest):
             ),
             std_mape=calculate_std_for_singular_values_across_cross_validation_folds(
                 fold_metrics, AccuracyMetricNames.MAPE
+            ),
+            mean_smape=calculate_mean_for_singular_values_across_cross_validation_folds(
+                fold_metrics, AccuracyMetricNames.SMAPE
+            ),
+            std_smape=calculate_std_for_singular_values_across_cross_validation_folds(
+                fold_metrics, AccuracyMetricNames.SMAPE
             ),
             mean_r_squared=calculate_mean_for_singular_values_across_cross_validation_folds(
                 fold_metrics, AccuracyMetricNames.R_SQUARED

--- a/mmm_eval/metrics/__init__.py
+++ b/mmm_eval/metrics/__init__.py
@@ -6,6 +6,7 @@ from .accuracy_functions import (
     calculate_means_for_series_across_cross_validation_folds,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
+    calculate_smape,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "calculate_mean_for_singular_values_across_cross_validation_folds",
     "calculate_std_for_singular_values_across_cross_validation_folds",
     "calculate_absolute_percentage_change",
+    "calculate_smape",
 ]

--- a/mmm_eval/metrics/__init__.py
+++ b/mmm_eval/metrics/__init__.py
@@ -4,9 +4,9 @@ from .accuracy_functions import (
     calculate_absolute_percentage_change,
     calculate_mean_for_singular_values_across_cross_validation_folds,
     calculate_means_for_series_across_cross_validation_folds,
+    calculate_smape,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
-    calculate_smape,
 )
 
 __all__ = [

--- a/mmm_eval/metrics/__init__.py
+++ b/mmm_eval/metrics/__init__.py
@@ -4,10 +4,10 @@ from .accuracy_functions import (
     calculate_absolute_percentage_change,
     calculate_mean_for_singular_values_across_cross_validation_folds,
     calculate_means_for_series_across_cross_validation_folds,
-    calculate_smape,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
 )
+from .metric_models import calculate_smape
 
 __all__ = [
     "calculate_means_for_series_across_cross_validation_folds",

--- a/mmm_eval/metrics/accuracy_functions.py
+++ b/mmm_eval/metrics/accuracy_functions.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pandas as pd
 
-from mmm_eval.metrics.metric_models import AccuracyMetricNames, AccuracyMetricResults, calculate_smape
+from mmm_eval.metrics.metric_models import AccuracyMetricNames, AccuracyMetricResults
 
 
 def calculate_mean_for_singular_values_across_cross_validation_folds(
@@ -74,4 +74,4 @@ def calculate_stds_for_series_across_cross_validation_folds(
 
 def calculate_absolute_percentage_change(baseline_series: pd.Series, comparison_series: pd.Series) -> pd.Series:
     """Calculate the absolute percentage change between two series."""
-    return np.abs((comparison_series - baseline_series) / baseline_series)
+    return 100 * np.abs((comparison_series - baseline_series) / baseline_series)

--- a/mmm_eval/metrics/accuracy_functions.py
+++ b/mmm_eval/metrics/accuracy_functions.py
@@ -3,43 +3,7 @@
 import numpy as np
 import pandas as pd
 
-from mmm_eval.metrics.metric_models import AccuracyMetricNames, AccuracyMetricResults
-
-
-def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
-    """Calculate Symmetric Mean Absolute Percentage Error (SMAPE).
-
-    SMAPE is calculated as: 100 * (2 * |actual - predicted|) / (|actual| + |predicted|)
-
-    Args:
-        actual: Actual values
-        predicted: Predicted values
-
-    Returns:
-        SMAPE value as float (percentage)
-
-    Raises:
-        ValueError: If series are empty or have different lengths
-
-    """
-    # Validate inputs
-    if len(actual) == 0 or len(predicted) == 0:
-        raise ValueError("Cannot calculate SMAPE on empty series")
-
-    if len(actual) != len(predicted):
-        raise ValueError("Actual and predicted series must have the same length")
-
-    # Handle NaN values
-    if actual.isna().any() or predicted.isna().any():
-        return float(np.nan)
-
-    # Handle division by zero and edge cases
-    denominator = np.abs(actual) + np.abs(predicted)
-    # Avoid division by zero by setting denominator to 1 where it's 0
-    denominator = np.where(denominator == 0, 1, denominator)
-
-    smape = 100 * np.mean(2 * np.abs(actual - predicted) / denominator)
-    return float(smape)
+from mmm_eval.metrics.metric_models import AccuracyMetricNames, AccuracyMetricResults, calculate_smape
 
 
 def calculate_mean_for_singular_values_across_cross_validation_folds(

--- a/mmm_eval/metrics/accuracy_functions.py
+++ b/mmm_eval/metrics/accuracy_functions.py
@@ -6,6 +6,27 @@ import pandas as pd
 from mmm_eval.metrics.metric_models import AccuracyMetricNames, AccuracyMetricResults
 
 
+def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
+    """Calculate Symmetric Mean Absolute Percentage Error (SMAPE).
+    
+    SMAPE is calculated as: 100 * (2 * |actual - predicted|) / (|actual| + |predicted|)
+    
+    Args:
+        actual: Actual values
+        predicted: Predicted values
+        
+    Returns:
+        SMAPE value as float (percentage)
+    """
+    # Handle division by zero and edge cases
+    denominator = np.abs(actual) + np.abs(predicted)
+    # Avoid division by zero by setting denominator to 1 where it's 0
+    denominator = np.where(denominator == 0, 1, denominator)
+    
+    smape = 100 * np.mean(2 * np.abs(actual - predicted) / denominator)
+    return float(smape)
+
+
 def calculate_mean_for_singular_values_across_cross_validation_folds(
     fold_metrics: list[AccuracyMetricResults],
     metric_name: AccuracyMetricNames,

--- a/mmm_eval/metrics/accuracy_functions.py
+++ b/mmm_eval/metrics/accuracy_functions.py
@@ -8,21 +8,36 @@ from mmm_eval.metrics.metric_models import AccuracyMetricNames, AccuracyMetricRe
 
 def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
     """Calculate Symmetric Mean Absolute Percentage Error (SMAPE).
-    
+
     SMAPE is calculated as: 100 * (2 * |actual - predicted|) / (|actual| + |predicted|)
-    
+
     Args:
         actual: Actual values
         predicted: Predicted values
-        
+
     Returns:
         SMAPE value as float (percentage)
+
+    Raises:
+        ValueError: If series are empty or have different lengths
+
     """
+    # Validate inputs
+    if len(actual) == 0 or len(predicted) == 0:
+        raise ValueError("Cannot calculate SMAPE on empty series")
+
+    if len(actual) != len(predicted):
+        raise ValueError("Actual and predicted series must have the same length")
+
+    # Handle NaN values
+    if actual.isna().any() or predicted.isna().any():
+        return float(np.nan)
+
     # Handle division by zero and edge cases
     denominator = np.abs(actual) + np.abs(predicted)
     # Avoid division by zero by setting denominator to 1 where it's 0
     denominator = np.where(denominator == 0, 1, denominator)
-    
+
     smape = 100 * np.mean(2 * np.abs(actual - predicted) / denominator)
     return float(smape)
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -39,14 +39,14 @@ def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
     
     # Handle NaN values
     if actual.isna().any() or predicted.isna().any():
-        return float(np.nan)
+        raise ValueError("Actual and predicted series must be free of NaN values")
     
     # Handle division by zero and edge cases
     denominator = np.abs(actual) + np.abs(predicted)
     # Avoid division by zero by setting denominator to 1 where it's 0
     denominator = np.where(denominator == 0, 1, denominator)
     
-    smape = 100 * np.mean(2 * np.abs(actual - predicted) / denominator)
+    smape = 100 * np.mean(2 * np.abs(predicted - actual) / denominator)
     return float(smape)
 
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -42,12 +42,12 @@ def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
     if actual.isna().any() or predicted.isna().any():
         raise ValueError("Actual and predicted series must be free of NaN values")
 
-    # Handle division by zero and edge cases
+    numerator = 2 * np.abs(predicted - actual)
     denominator = np.abs(actual) + np.abs(predicted)
-    # Avoid division by zero by setting denominator to 1 where it's 0
-    denominator = np.where(denominator == 0, 1, denominator)
-
-    smape = 100 * np.mean(2 * np.abs(predicted - actual) / denominator)
+    # avoid division by zero edge case if both numerator and denominator are zero
+    mask = denominator != 0
+    smape_terms = np.where(mask, numerator / denominator, 0)
+    smape = 100 * np.mean(smape_terms)
     return float(smape)
 
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -17,35 +17,36 @@ from mmm_eval.metrics.threshold_constants import (
 
 def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
     """Calculate Symmetric Mean Absolute Percentage Error (SMAPE).
-    
+
     SMAPE is calculated as: 100 * (2 * |actual - predicted|) / (|actual| + |predicted|)
-    
+
     Args:
         actual: Actual values
         predicted: Predicted values
-        
+
     Returns:
         SMAPE value as float (percentage)
-        
+
     Raises:
         ValueError: If series are empty or have different lengths
+
     """
     # Validate inputs
     if len(actual) == 0 or len(predicted) == 0:
         raise ValueError("Cannot calculate SMAPE on empty series")
-    
+
     if len(actual) != len(predicted):
         raise ValueError("Actual and predicted series must have the same length")
-    
+
     # Handle NaN values
     if actual.isna().any() or predicted.isna().any():
         raise ValueError("Actual and predicted series must be free of NaN values")
-    
+
     # Handle division by zero and edge cases
     denominator = np.abs(actual) + np.abs(predicted)
     # Avoid division by zero by setting denominator to 1 where it's 0
     denominator = np.where(denominator == 0, 1, denominator)
-    
+
     smape = 100 * np.mean(2 * np.abs(predicted - actual) / denominator)
     return float(smape)
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -1,10 +1,10 @@
 from enum import Enum
 from typing import Any
 
+import numpy as np
 import pandas as pd
 from pydantic import BaseModel, ConfigDict
 from sklearn.metrics import mean_absolute_percentage_error, r2_score
-import numpy as np
 
 from mmm_eval.metrics.exceptions import InvalidMetricNameException
 from mmm_eval.metrics.threshold_constants import (
@@ -193,7 +193,7 @@ class AccuracyMetricResults(MetricResults):
         # Avoid division by zero by setting denominator to 1 where it's 0
         denominator = np.where(denominator == 0, 1, denominator)
         smape = 100 * np.mean(2 * np.abs(actual - predicted) / denominator)
-        
+
         return cls(
             mape=mean_absolute_percentage_error(actual, predicted),
             smape=float(smape),

--- a/mmm_eval/metrics/threshold_constants.py
+++ b/mmm_eval/metrics/threshold_constants.py
@@ -15,20 +15,20 @@ class CrossValidationThresholdConstants:
     """Constants for the cross-validation threshold."""
 
     MEAN_MAPE = 15.0
-    STD_MAPE = 3.0
+    STD_MAPE = 5.0
     MEAN_SMAPE = 15.0
-    STD_SMAPE = 3.0
+    STD_SMAPE = 5.0
     MEAN_R_SQUARED = 0.8
 
 
 class RefreshStabilityThresholdConstants:
     """Constants for the refresh stability threshold."""
 
-    MEAN_PERCENTAGE_CHANGE = 0.15
-    STD_PERCENTAGE_CHANGE = 0.03
+    MEAN_PERCENTAGE_CHANGE = 15.0
+    STD_PERCENTAGE_CHANGE = 3.0
 
 
 class PerturbationThresholdConstants:
     """Constants for the perturbation threshold."""
 
-    PERCENTAGE_CHANGE = 0.08
+    PERCENTAGE_CHANGE = 8.0

--- a/mmm_eval/metrics/threshold_constants.py
+++ b/mmm_eval/metrics/threshold_constants.py
@@ -7,6 +7,7 @@ class AccuracyThresholdConstants:
     """Constants for the accuracy threshold."""
 
     MAPE = 0.15
+    SMAPE = 0.15
     R_SQUARED = 0.8
 
 
@@ -15,6 +16,8 @@ class CrossValidationThresholdConstants:
 
     MEAN_MAPE = 0.15
     STD_MAPE = 0.03
+    MEAN_SMAPE = 0.15
+    STD_SMAPE = 0.03
     MEAN_R_SQUARED = 0.8
 
 

--- a/mmm_eval/metrics/threshold_constants.py
+++ b/mmm_eval/metrics/threshold_constants.py
@@ -6,18 +6,18 @@
 class AccuracyThresholdConstants:
     """Constants for the accuracy threshold."""
 
-    MAPE = 0.15
-    SMAPE = 0.15
+    MAPE = 15.0
+    SMAPE = 15.0
     R_SQUARED = 0.8
 
 
 class CrossValidationThresholdConstants:
     """Constants for the cross-validation threshold."""
 
-    MEAN_MAPE = 0.15
-    STD_MAPE = 0.03
-    MEAN_SMAPE = 0.15
-    STD_SMAPE = 0.03
+    MEAN_MAPE = 15.0
+    STD_MAPE = 3.0
+    MEAN_SMAPE = 15.0
+    STD_SMAPE = 3.0
     MEAN_R_SQUARED = 0.8
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mmm-eval"
-version = "0.8.0"
+version = "0.9.0"
 description = "Open-source evaluation of marketing mix model (MMM) performance"
 authors = ["Joseph Kang <joseph.kang@mutinex.co>",
            "Phil Clark <phil.clark@mutinex.co>",

--- a/tests/test_accuracy_functions.py
+++ b/tests/test_accuracy_functions.py
@@ -8,13 +8,13 @@ from mmm_eval.metrics.accuracy_functions import (
     calculate_absolute_percentage_change,
     calculate_mean_for_singular_values_across_cross_validation_folds,
     calculate_means_for_series_across_cross_validation_folds,
-    calculate_smape,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
 )
 from mmm_eval.metrics.metric_models import (
     AccuracyMetricNames,
     AccuracyMetricResults,
+    calculate_smape,
 )
 
 

--- a/tests/test_accuracy_functions.py
+++ b/tests/test_accuracy_functions.py
@@ -38,7 +38,7 @@ class TestCalculateAbsolutePercentageChange:
 
         result = calculate_absolute_percentage_change(baseline, comparison)
 
-        assert all(result == 0.1)  # 10% absolute change
+        assert all(result == 10.0)  # 10% absolute change
         assert isinstance(result, pd.Series)
 
     def test_zero_baseline_handling(self):
@@ -51,8 +51,8 @@ class TestCalculateAbsolutePercentageChange:
         # Check that the first element is inf (division by zero)
         assert np.isinf(result.iloc[0])
         # Check that other elements are calculated correctly
-        assert result.iloc[1] == pytest.approx(0.1)  # (110-100)/100 = 0.1
-        assert result.iloc[2] == pytest.approx(0.05)  # (210-200)/200 = 0.05
+        assert result.iloc[1] == pytest.approx(10.0)  # (110-100)/100 = 10%
+        assert result.iloc[2] == pytest.approx(5.0)  # (210-200)/200 = 5%
 
 
 class TestCrossValidationFoldCalculations:
@@ -268,8 +268,5 @@ class TestCalculateSMAPE:
         actual = pd.Series([100, np.nan, 300])
         predicted = pd.Series([110, 220, np.nan])
 
-        result = calculate_smape(actual, predicted)
-
-        # Should handle NaN values gracefully
-        assert np.isnan(result)
-        assert isinstance(result, float)
+        with pytest.raises(ValueError, match="Actual and predicted series must be free of NaN values"):
+            calculate_smape(actual, predicted)

--- a/tests/test_accuracy_functions.py
+++ b/tests/test_accuracy_functions.py
@@ -8,6 +8,7 @@ from mmm_eval.metrics.accuracy_functions import (
     calculate_absolute_percentage_change,
     calculate_mean_for_singular_values_across_cross_validation_folds,
     calculate_means_for_series_across_cross_validation_folds,
+    calculate_smape,
     calculate_std_for_singular_values_across_cross_validation_folds,
     calculate_stds_for_series_across_cross_validation_folds,
 )
@@ -60,9 +61,9 @@ class TestCrossValidationFoldCalculations:
     def test_calculate_mean_for_singular_values_across_cross_validation_folds(self):
         """Test mean calculation across folds for single values."""
         fold_metrics = [
-            AccuracyMetricResults(mape=0.1, r_squared=0.8),
-            AccuracyMetricResults(mape=0.2, r_squared=0.7),
-            AccuracyMetricResults(mape=0.3, r_squared=0.9),
+            AccuracyMetricResults(mape=0.1, smape=0.095, r_squared=0.8),
+            AccuracyMetricResults(mape=0.2, smape=0.105, r_squared=0.7),
+            AccuracyMetricResults(mape=0.3, smape=0.115, r_squared=0.9),
         ]
 
         result = calculate_mean_for_singular_values_across_cross_validation_folds(
@@ -76,9 +77,9 @@ class TestCrossValidationFoldCalculations:
     def test_calculate_std_for_singular_values_across_cross_validation_folds(self):
         """Test standard deviation calculation across folds for single values."""
         fold_metrics = [
-            AccuracyMetricResults(mape=0.1, r_squared=0.8),
-            AccuracyMetricResults(mape=0.2, r_squared=0.7),
-            AccuracyMetricResults(mape=0.3, r_squared=0.9),
+            AccuracyMetricResults(mape=0.1, smape=0.095, r_squared=0.8),
+            AccuracyMetricResults(mape=0.2, smape=0.105, r_squared=0.7),
+            AccuracyMetricResults(mape=0.3, smape=0.115, r_squared=0.9),
         ]
 
         result = calculate_std_for_singular_values_across_cross_validation_folds(fold_metrics, AccuracyMetricNames.MAPE)
@@ -120,3 +121,155 @@ class TestCrossValidationFoldCalculations:
         assert result["channel_1"] == pytest.approx(expected_channel_1)
         assert result["channel_2"] == pytest.approx(expected_channel_2)
         assert isinstance(result, pd.Series)
+
+
+class TestCalculateSMAPE:
+    """Test cases for Symmetric Mean Absolute Percentage Error (SMAPE) calculation."""
+
+    def test_perfect_predictions(self):
+        """Test SMAPE with perfect predictions (should be 0)."""
+        actual = pd.Series([100, 200, 300])
+        predicted = pd.Series([100, 200, 300])
+
+        result = calculate_smape(actual, predicted)
+
+        assert result == 0.0
+        assert isinstance(result, float)
+
+    def test_constant_percentage_error_overestimation(self):
+        """Test SMAPE with constant percentage overestimation."""
+        actual = pd.Series([100, 200, 300])
+        predicted = pd.Series([110, 220, 330])  # 10% overestimation
+
+        result = calculate_smape(actual, predicted)
+
+        # Expected SMAPE for 10% overestimation
+        # SMAPE = 100 * (2 * |actual - predicted|) / (|actual| + |predicted|)
+        # For 10% overestimation: (2 * 10) / (100 + 110) = 20/210 ≈ 9.52%
+        expected = 100 * (2 * 10) / (100 + 110)
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_constant_percentage_error_underestimation(self):
+        """Test SMAPE with constant percentage underestimation."""
+        actual = pd.Series([100, 200, 300])
+        predicted = pd.Series([90, 180, 270])  # 10% underestimation
+
+        result = calculate_smape(actual, predicted)
+
+        # Expected SMAPE for 10% underestimation
+        # SMAPE = 100 * (2 * |actual - predicted|) / (|actual| + |predicted|)
+        # For 10% underestimation: (2 * 10) / (100 + 90) = 20/190 ≈ 10.53%
+        expected = 100 * (2 * 10) / (100 + 90)
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_mixed_errors(self):
+        """Test SMAPE with mixed over and underestimation errors."""
+        actual = pd.Series([100, 200, 300])
+        predicted = pd.Series([110, 180, 330])  # Mixed errors
+
+        result = calculate_smape(actual, predicted)
+
+        # Calculate expected manually
+        # Error 1: (2 * 10) / (100 + 110) = 20/210 ≈ 0.0952
+        # Error 2: (2 * 20) / (200 + 180) = 40/380 ≈ 0.1053
+        # Error 3: (2 * 30) / (300 + 330) = 60/630 ≈ 0.0952
+        # Average: (0.0952 + 0.1053 + 0.0952) / 3 ≈ 0.0986
+        expected = 100 * ((2 * 10) / (100 + 110) + (2 * 20) / (200 + 180) + (2 * 30) / (300 + 330)) / 3
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_zero_values_handling(self):
+        """Test SMAPE handling of zero values."""
+        actual = pd.Series([0, 100, 200])
+        predicted = pd.Series([10, 110, 210])
+
+        result = calculate_smape(actual, predicted)
+
+        # For zero actual value, denominator becomes |predicted| to avoid division by zero
+        # Error 1: (2 * 10) / (0 + 10) = 20/10 = 2.0
+        # Error 2: (2 * 10) / (100 + 110) = 20/210 ≈ 0.0952
+        # Error 3: (2 * 10) / (200 + 210) = 20/410 ≈ 0.0488
+        # Average: (2.0 + 0.0952 + 0.0488) / 3 ≈ 0.7147
+        expected = 100 * ((2 * 10) / (0 + 10) + (2 * 10) / (100 + 110) + (2 * 10) / (200 + 210)) / 3
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_both_zero_values(self):
+        """Test SMAPE when both actual and predicted are zero."""
+        actual = pd.Series([0, 100, 0])
+        predicted = pd.Series([0, 110, 0])
+
+        result = calculate_smape(actual, predicted)
+
+        # When both actual and predicted are zero, denominator becomes 1 to avoid division by zero
+        # Error 1: (2 * 0) / 1 = 0
+        # Error 2: (2 * 10) / (100 + 110) = 20/210 ≈ 0.0952
+        # Error 3: (2 * 0) / 1 = 0
+        # Average: (0 + 0.0952 + 0) / 3 ≈ 0.0317
+        expected = 100 * (0 + (2 * 10) / (100 + 110) + 0) / 3
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_single_value(self):
+        """Test SMAPE with single value."""
+        actual = pd.Series([100])
+        predicted = pd.Series([110])
+
+        result = calculate_smape(actual, predicted)
+
+        expected = 100 * (2 * 10) / (100 + 110)
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_large_numbers(self):
+        """Test SMAPE with large numbers."""
+        actual = pd.Series([1000000, 2000000, 3000000])
+        predicted = pd.Series([1100000, 2200000, 3300000])  # 10% overestimation
+
+        result = calculate_smape(actual, predicted)
+
+        # Should give same percentage as smaller numbers
+        expected = 100 * (2 * 100000) / (1000000 + 1100000)
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_negative_values(self):
+        """Test SMAPE with negative values."""
+        actual = pd.Series([-100, -200, -300])
+        predicted = pd.Series([-110, -220, -330])  # 10% overestimation
+
+        result = calculate_smape(actual, predicted)
+
+        # SMAPE should work with absolute values
+        expected = 100 * (2 * 10) / (100 + 110)
+        assert result == pytest.approx(expected, rel=1e-10)
+        assert isinstance(result, float)
+
+    def test_empty_series(self):
+        """Test SMAPE with empty series (should raise error)."""
+        actual = pd.Series([])
+        predicted = pd.Series([])
+
+        with pytest.raises(ValueError):
+            calculate_smape(actual, predicted)
+
+    def test_different_lengths(self):
+        """Test SMAPE with different length series (should raise error)."""
+        actual = pd.Series([100, 200])
+        predicted = pd.Series([110, 220, 330])
+
+        with pytest.raises(ValueError):
+            calculate_smape(actual, predicted)
+
+    def test_nan_values(self):
+        """Test SMAPE with NaN values."""
+        actual = pd.Series([100, np.nan, 300])
+        predicted = pd.Series([110, 220, np.nan])
+
+        result = calculate_smape(actual, predicted)
+
+        # Should handle NaN values gracefully
+        assert np.isnan(result)
+        assert isinstance(result, float)

--- a/tests/test_base_validation_test.py
+++ b/tests/test_base_validation_test.py
@@ -10,6 +10,7 @@ from mmm_eval.core.base_validation_test import (
     split_timeseries_cv,
     split_timeseries_data,
 )
+from mmm_eval.core.constants import ValidationTestConstants
 from mmm_eval.core.exceptions import MetricCalculationError, TestExecutionError
 from mmm_eval.data.constants import InputDataframeConstants
 
@@ -34,18 +35,24 @@ class TestBaseValidationTest:
         """Set up test data."""
         self.test_instance = ConcreteTestClass(InputDataframeConstants.DATE_COL)
 
-        # Create comprehensive test data (40 points - minimum for data validation)
+        # Calculate minimum required data size based on constants
+        # Required: test_size * (n_splits + 1) = TIME_SERIES_CROSS_VALIDATION_TEST_SIZE * (N_SPLITS + 1)
+        min_required_size = ValidationTestConstants.TIME_SERIES_CROSS_VALIDATION_TEST_SIZE * (
+            ValidationTestConstants.N_SPLITS + 1
+        )
+
+        # Create comprehensive test data (minimum for data validation)
         # This serves as the lowest common denominator for all tests
         self.test_data = pd.DataFrame(
             {
-                InputDataframeConstants.DATE_COL: pd.date_range("2023-01-01", periods=40),
-                "media_channel": ["TV", "Radio"] * 20,  # 42 total, but we'll use 40
-                InputDataframeConstants.MEDIA_CHANNEL_SPEND_COL: [110, 220] * 20,
-                InputDataframeConstants.RESPONSE_COL: [160, 260] * 20,
+                InputDataframeConstants.DATE_COL: pd.date_range("2023-01-01", periods=min_required_size),
+                "media_channel": ["TV", "Radio"] * (min_required_size // 2),
+                InputDataframeConstants.MEDIA_CHANNEL_SPEND_COL: [110, 220] * (min_required_size // 2),
+                InputDataframeConstants.RESPONSE_COL: [160, 260] * (min_required_size // 2),
             }
         )
-        # Trim to exactly 40 rows
-        self.test_data = self.test_data.head(40)
+        # Trim to exactly the required size
+        self.test_data = self.test_data.head(min_required_size)
 
         # Create insufficient data for time series CV error testing (10 points)
         self.insufficient_data = pd.DataFrame(
@@ -76,8 +83,8 @@ class TestBaseValidationTest:
         cv_splits = self.test_instance._split_data_time_series_cv(self.test_data)
         splits_list = list(cv_splits)
 
-        # Check that we get the expected number of splits (N_SPLITS = 5)
-        assert len(splits_list) == 5
+        # Check that we get the expected number of splits
+        assert len(splits_list) == ValidationTestConstants.N_SPLITS
 
         # Check that each split has train and test masks
         for i, (train_mask, test_mask) in enumerate(splits_list):
@@ -91,22 +98,13 @@ class TestBaseValidationTest:
             # Check that train and test are disjoint
             assert not (train_mask & test_mask).any()
 
-            # Check that test size is correct (TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4)
-            assert test_mask.sum() == 4
+            # Check that test size is correct
+            assert test_mask.sum() == ValidationTestConstants.TIME_SERIES_CROSS_VALIDATION_TEST_SIZE
 
             # Check that train size decreases with each split (rolling window behavior)
-            if i == 0:
-                expected_train_size = 36  # 40 - 4
-            elif i == 1:
-                expected_train_size = 32  # 40 - 8
-            elif i == 2:
-                expected_train_size = 28  # 40 - 12
-            elif i == 3:
-                expected_train_size = 24  # 40 - 16
-            elif i == 4:
-                expected_train_size = 20  # 40 - 20
-            else:
-                raise AssertionError(f"Unexpected split index: {i}")
+            total_data_size = len(self.test_data)
+            test_size = ValidationTestConstants.TIME_SERIES_CROSS_VALIDATION_TEST_SIZE
+            expected_train_size = total_data_size - test_size * (i + 1)
             assert train_mask.sum() == expected_train_size
 
     def test_split_data_time_series_cv_insufficient_data(self):
@@ -121,8 +119,8 @@ class TestBaseValidationTest:
         cv_splits = self.test_instance._split_data_time_series_cv(self.test_data)
         splits_list = list(cv_splits)
 
-        # Should get exactly 5 splits
-        assert len(splits_list) == 5
+        # Should get exactly the expected number of splits
+        assert len(splits_list) == ValidationTestConstants.N_SPLITS
 
     def test_split_timeseries_data_basic(self):
         """Test basic functionality of split_timeseries_data."""

--- a/tests/test_metric_models.py
+++ b/tests/test_metric_models.py
@@ -22,29 +22,29 @@ class TestAccuracyMetricResults:
 
     def test_accuracy_metric_threshold_checking_good_metrics(self):
         """Test accuracy metric threshold checking with good metrics."""
-        results = AccuracyMetricResults(mape=0.1, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
 
         # Test individual metric threshold checking
-        assert results._check_metric_threshold(AccuracyMetricNames.MAPE.value, 0.1) is True
+        assert results._check_metric_threshold(AccuracyMetricNames.MAPE.value, 10.0) is True
         assert results._check_metric_threshold(AccuracyMetricNames.R_SQUARED.value, 0.85) is True
 
     def test_accuracy_metric_threshold_checking_bad_metrics(self):
         """Test accuracy metric threshold checking with bad metrics."""
-        results = AccuracyMetricResults(mape=0.1, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
 
         # Test individual metric threshold checking
-        assert results._check_metric_threshold(AccuracyMetricNames.MAPE.value, 0.2) is False
+        assert results._check_metric_threshold(AccuracyMetricNames.MAPE.value, 20.0) is False
         assert results._check_metric_threshold(AccuracyMetricNames.R_SQUARED.value, 0.75) is False
 
     def test_accuracy_metric_dataframe_output(self):
         """Test accuracy metric results DataFrame output."""
-        results = AccuracyMetricResults(mape=0.1, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
         df = results.to_df()
 
         # Check DataFrame structure
         expected_columns = TestResultDFAttributes.to_list()
         assert list(df.columns) == expected_columns
-        assert len(df) == 2
+        assert len(df) == 3
 
         # Check metric values
         mape_row = df[df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == AccuracyMetricNames.MAPE.value].iloc[0]
@@ -52,14 +52,14 @@ class TestAccuracyMetricResults:
             df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == AccuracyMetricNames.R_SQUARED.value
         ].iloc[0]
 
-        assert mape_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.1
+        assert mape_row[TestResultDFAttributes.METRIC_VALUE.value] == 10.0
         assert r_squared_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.85
         assert mape_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
         assert r_squared_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
 
     def test_accuracy_metric_invalid_metric_name(self):
         """Test accuracy metric with invalid metric name."""
-        results = AccuracyMetricResults(mape=0.1, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
 
         with pytest.raises(InvalidMetricNameException):
             results._check_metric_threshold("invalid_metric", 0.1)
@@ -70,38 +70,38 @@ class TestCrossValidationMetricResults:
 
     def test_cross_validation_metric_threshold_checking_good_metrics(self):
         """Test cross-validation metric threshold checking with good metrics."""
-        results = CrossValidationMetricResults(mean_mape=0.12, std_mape=0.02, mean_r_squared=0.85)
+        results = CrossValidationMetricResults(mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85)
 
         # Test individual metric threshold checking
-        assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_MAPE.value, 0.12) is True
-        assert results._check_metric_threshold(CrossValidationMetricNames.STD_MAPE.value, 0.02) is True
+        assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_MAPE.value, 12.0) is True
+        assert results._check_metric_threshold(CrossValidationMetricNames.STD_MAPE.value, 2.0) is True
         assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_R_SQUARED.value, 0.85) is True
 
     def test_cross_validation_metric_threshold_checking_bad_metrics(self):
         """Test cross-validation metric threshold checking with bad metrics."""
-        results = CrossValidationMetricResults(mean_mape=0.12, std_mape=0.02, mean_r_squared=0.85)
+        results = CrossValidationMetricResults(mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85)
 
         # Test individual metric threshold checking
-        assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_MAPE.value, 0.16) is False
+        assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_MAPE.value, 16.0) is False
         assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_R_SQUARED.value, 0.75) is False
 
     def test_cross_validation_metric_dataframe_output(self):
         """Test cross-validation metric results DataFrame output."""
-        results = CrossValidationMetricResults(mean_mape=0.12, std_mape=0.02, mean_r_squared=0.85)
+        results = CrossValidationMetricResults(mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85)
         df = results.to_df()
 
         # Check DataFrame structure
         expected_columns = TestResultDFAttributes.to_list()
         assert list(df.columns) == expected_columns
-        assert len(df) == 3
+        assert len(df) == 5
 
         # Check metric values
         mean_mape_row = df[df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == "mean_mape"].iloc[0]
         std_mape_row = df[df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == "std_mape"].iloc[0]
         mean_r_squared_row = df[df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == "mean_r_squared"].iloc[0]
 
-        assert mean_mape_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.12
-        assert std_mape_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.02
+        assert mean_mape_row[TestResultDFAttributes.METRIC_VALUE.value] == 12.0
+        assert std_mape_row[TestResultDFAttributes.METRIC_VALUE.value] == 2.0
         assert mean_r_squared_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.85
         assert mean_mape_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
         assert std_mape_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
@@ -113,34 +113,23 @@ class TestRefreshStabilityMetricResults:
 
     def test_stability_metric_threshold_checking_good_metrics(self):
         """Test stability metric threshold checking with good metrics."""
-        mean_series = pd.Series({"channel_1": 0.1, "channel_2": 0.05})
-        std_series = pd.Series({"channel_1": 0.02, "channel_2": 0.01})
+        mean_series = pd.Series({"channel_1": 10.0, "channel_2": 5.0})
+        std_series = pd.Series({"channel_1": 2.0, "channel_2": 1.0})
         results = RefreshStabilityMetricResults(
             mean_percentage_change_for_each_channel=mean_series,
             std_percentage_change_for_each_channel=std_series,
         )
 
-        # Test individual metric threshold checking
-        assert results._check_metric_threshold(RefreshStabilityMetricNames.MEAN_PERCENTAGE_CHANGE.value, 0.1) is True
-        assert results._check_metric_threshold(RefreshStabilityMetricNames.STD_PERCENTAGE_CHANGE.value, 0.02) is True
-
-    def test_stability_metric_threshold_checking_bad_metrics(self):
-        """Test stability metric threshold checking with bad metrics."""
-        mean_series = pd.Series({"channel_1": 0.1, "channel_2": 0.05})
-        std_series = pd.Series({"channel_1": 0.02, "channel_2": 0.01})
-        results = RefreshStabilityMetricResults(
-            mean_percentage_change_for_each_channel=mean_series,
-            std_percentage_change_for_each_channel=std_series,
-        )
-
-        # Test individual metric threshold checking
-        assert results._check_metric_threshold(RefreshStabilityMetricNames.MEAN_PERCENTAGE_CHANGE.value, 0.16) is False
-        assert results._check_metric_threshold(RefreshStabilityMetricNames.STD_PERCENTAGE_CHANGE.value, 0.06) is False
+        # Test refresh stability threshold checking
+        assert results._check_metric_threshold(RefreshStabilityMetricNames.MEAN_PERCENTAGE_CHANGE.value, 10.0) is True
+        assert results._check_metric_threshold(RefreshStabilityMetricNames.STD_PERCENTAGE_CHANGE.value, 2.0) is True
+        assert results._check_metric_threshold(RefreshStabilityMetricNames.MEAN_PERCENTAGE_CHANGE.value, 16.0) is False
+        assert results._check_metric_threshold(RefreshStabilityMetricNames.STD_PERCENTAGE_CHANGE.value, 6.0) is False
 
     def test_stability_metric_dataframe_output(self):
         """Test stability metric results DataFrame output."""
-        mean_series = pd.Series({"channel_1": 0.1, "channel_2": 0.05})
-        std_series = pd.Series({"channel_1": 0.02, "channel_2": 0.01})
+        mean_series = pd.Series({"channel_1": 10.0, "channel_2": 5.0})
+        std_series = pd.Series({"channel_1": 2.0, "channel_2": 1.0})
         results = RefreshStabilityMetricResults(
             mean_percentage_change_for_each_channel=mean_series,
             std_percentage_change_for_each_channel=std_series,
@@ -160,8 +149,8 @@ class TestRefreshStabilityMetricResults:
             df[TestResultDFAttributes.SPECIFIC_METRIC_NAME.value] == "std_percentage_change_channel_2"
         ].iloc[0]
 
-        assert channel1_mean_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.1
-        assert channel2_std_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.01
+        assert channel1_mean_row[TestResultDFAttributes.METRIC_VALUE.value] == 10.0
+        assert channel2_std_row[TestResultDFAttributes.METRIC_VALUE.value] == 1.0
         assert channel1_mean_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
         assert channel2_std_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
 
@@ -171,24 +160,25 @@ class TestPerturbationMetricResults:
 
     def test_perturbation_metric_threshold_checking_good_metrics(self):
         """Test perturbation metric threshold checking with good metrics."""
-        percentage_change_series = pd.Series({"TV": 0.03, "Radio": 0.07})
+        percentage_change_series = pd.Series({"TV": 3.0, "Radio": 7.0})
         results = PerturbationMetricResults(percentage_change_for_each_channel=percentage_change_series)
 
-        # Test individual metric threshold checking
-        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 0.03) is True
-        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 0.07) is True
+        # Test perturbation threshold checking
+        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 3.0) is True
+        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 7.0) is True
+        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 11.0) is False
 
     def test_perturbation_metric_threshold_checking_bad_metrics(self):
         """Test perturbation metric threshold checking with bad metrics."""
-        percentage_change_series = pd.Series({"TV": 0.03, "Radio": 0.07})
+        percentage_change_series = pd.Series({"TV": 3.0, "Radio": 7.0})
         results = PerturbationMetricResults(percentage_change_for_each_channel=percentage_change_series)
 
         # Test individual metric threshold checking
-        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 0.11) is False
+        assert results._check_metric_threshold(PerturbationMetricNames.PERCENTAGE_CHANGE.value, 11.0) is False
 
     def test_perturbation_metric_dataframe_output(self):
         """Test perturbation metric results DataFrame output."""
-        percentage_change_series = pd.Series({"TV": 0.03, "Radio": 0.07})
+        percentage_change_series = pd.Series({"TV": 3.0, "Radio": 7.0})
         results = PerturbationMetricResults(percentage_change_for_each_channel=percentage_change_series)
         df = results.to_df()
 
@@ -201,7 +191,7 @@ class TestPerturbationMetricResults:
         tv_row = df[df[TestResultDFAttributes.SPECIFIC_METRIC_NAME.value] == "percentage_change_TV"].iloc[0]
         radio_row = df[df[TestResultDFAttributes.SPECIFIC_METRIC_NAME.value] == "percentage_change_Radio"].iloc[0]
 
-        assert tv_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.03
-        assert radio_row[TestResultDFAttributes.METRIC_VALUE.value] == 0.07
+        assert tv_row[TestResultDFAttributes.METRIC_VALUE.value] == 3.0
+        assert radio_row[TestResultDFAttributes.METRIC_VALUE.value] == 7.0
         assert tv_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712
         assert radio_row[TestResultDFAttributes.METRIC_PASS.value] == True  # noqa: E712

--- a/tests/test_metric_models.py
+++ b/tests/test_metric_models.py
@@ -70,7 +70,9 @@ class TestCrossValidationMetricResults:
 
     def test_cross_validation_metric_threshold_checking_good_metrics(self):
         """Test cross-validation metric threshold checking with good metrics."""
-        results = CrossValidationMetricResults(mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85)
+        results = CrossValidationMetricResults(
+            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85
+        )
 
         # Test individual metric threshold checking
         assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_MAPE.value, 12.0) is True
@@ -79,7 +81,9 @@ class TestCrossValidationMetricResults:
 
     def test_cross_validation_metric_threshold_checking_bad_metrics(self):
         """Test cross-validation metric threshold checking with bad metrics."""
-        results = CrossValidationMetricResults(mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85)
+        results = CrossValidationMetricResults(
+            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85
+        )
 
         # Test individual metric threshold checking
         assert results._check_metric_threshold(CrossValidationMetricNames.MEAN_MAPE.value, 16.0) is False
@@ -87,7 +91,9 @@ class TestCrossValidationMetricResults:
 
     def test_cross_validation_metric_dataframe_output(self):
         """Test cross-validation metric results DataFrame output."""
-        results = CrossValidationMetricResults(mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85)
+        results = CrossValidationMetricResults(
+            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85
+        )
         df = results.to_df()
 
         # Check DataFrame structure

--- a/tests/test_validation_test_results.py
+++ b/tests/test_validation_test_results.py
@@ -154,7 +154,7 @@ class TestValidationResults:
     def test_validation_result_to_df_with_series_metrics(self):
         """Test ValidationResults to_df conversion with Series-based metrics."""
         # Create test result with Series-based metrics
-        percentage_change_series = pd.Series({"TV": 0.03, "Radio": 0.07})
+        percentage_change_series = pd.Series({"TV": 3.0, "Radio": 7.0})
         perturbation_result = ValidationTestResult(
             test_name=ValidationTestNames.PERTURBATION,
             metric_names=["percentage_change_for_each_channel"],

--- a/tests/test_validation_test_results.py
+++ b/tests/test_validation_test_results.py
@@ -24,7 +24,7 @@ class TestValidationTestResult:
 
     def test_test_result_creation_and_to_df(self):
         """Test TestResult creation and to_df conversion."""
-        test_scores = AccuracyMetricResults(mape=0.1, r_squared=0.8)
+        test_scores = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8)
         metric_names = AccuracyMetricNames.to_list()
 
         result = ValidationTestResult(
@@ -103,12 +103,12 @@ class TestValidationResults:
         accuracy_result = ValidationTestResult(
             test_name=ValidationTestNames.ACCURACY,
             metric_names=AccuracyMetricNames.to_list(),
-            test_scores=AccuracyMetricResults(mape=0.1, r_squared=0.8),
+            test_scores=AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8),
         )
 
         # Create stability result with new field names
-        mean_series = pd.Series({"channel_1": 0.1, "channel_2": 0.05})
-        std_series = pd.Series({"channel_1": 0.02, "channel_2": 0.01})
+        mean_series = pd.Series({"channel_1": 10.0, "channel_2": 5.0})
+        std_series = pd.Series({"channel_1": 2.0, "channel_2": 1.0})
         stability_result = ValidationTestResult(
             test_name=ValidationTestNames.REFRESH_STABILITY,
             metric_names=RefreshStabilityMetricNames.to_list(),
@@ -137,7 +137,7 @@ class TestValidationResults:
         accuracy_result = ValidationTestResult(
             test_name=ValidationTestNames.ACCURACY,
             metric_names=AccuracyMetricNames.to_list(),
-            test_scores=AccuracyMetricResults(mape=0.1, r_squared=0.8),
+            test_scores=AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8),
         )
 
         test_results = {ValidationTestNames.ACCURACY: accuracy_result}
@@ -148,8 +148,8 @@ class TestValidationResults:
         assert isinstance(result_df, pd.DataFrame)
         assert ValidationTestAttributeNames.TEST_NAME.value in result_df.columns
         assert ValidationTestAttributeNames.TIMESTAMP.value in result_df.columns
-        # Should have 2 rows: one for each accuracy metric (mape and r_squared)
-        assert len(result_df) == 2
+        # Should have 3 rows: one for each accuracy metric (mape, smape, and r_squared)
+        assert len(result_df) == 3
 
     def test_validation_result_to_df_with_series_metrics(self):
         """Test ValidationResults to_df conversion with Series-based metrics."""


### PR DESCRIPTION
Introduces SMAPE as another default metric for accuracy and cross-validated accuracy tests.

Also, converts all metrics with "percentage" in the name to actual percentages, e.g. for MAPE 0.15 becomes 15. This will hopefully avoid confusion for users who may think their model is amazing with a MAPE of 0.7, when in reality that's 70% average error.

