### PR TITLE
Split data based on fixed test size rather than proportion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] ; 2025-07-17
+
+### Changed
+
+- Changed holdout split strategy for accuracy test to fixed test set size
+
 ## [0.7.1] ; 2025-07-15
 
 ### Fixed

--- a/mmm_eval/core/base_validation_test.py
+++ b/mmm_eval/core/base_validation_test.py
@@ -153,7 +153,7 @@ def split_timeseries_data(
             f"`test_size` ({test_size}) must be less than the number of unique dates ({len(sorted_dates)})"
         )
 
-    cutoff = sorted_dates[-test_size]  # Use the date before the test period starts
+    cutoff = sorted_dates[-test_size]
 
     train_mask = data[date_column] < cutoff
     test_mask = data[date_column] >= cutoff

--- a/mmm_eval/core/base_validation_test.py
+++ b/mmm_eval/core/base_validation_test.py
@@ -140,7 +140,7 @@ def split_timeseries_data(
 
     Raises:
         ValueError: if `test_size` is invalid.
-    
+
     """
     if test_size <= 0:
         raise ValueError("`test_size` must be greater than 0")

--- a/mmm_eval/core/base_validation_test.py
+++ b/mmm_eval/core/base_validation_test.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 
 import numpy as np
 import pandas as pd
-from pydantic import PositiveFloat, PositiveInt
+from pydantic import PositiveInt
 
 from mmm_eval.adapters.base import BaseAdapter
 from mmm_eval.core.constants import ValidationTestConstants
@@ -140,16 +140,19 @@ def split_timeseries_data(
 
     Raises:
         ValueError: if `test_size` is invalid.
+    
     """
     if test_size <= 0:
         raise ValueError("`test_size` must be greater than 0")
 
     sorted_dates = sorted(data[date_column].unique())
-    
+
     # Reserve the last test_size data points for testing
     if test_size >= len(sorted_dates):
-        raise ValueError(f"`test_size` ({test_size}) must be less than the number of unique dates ({len(sorted_dates)})")
-    
+        raise ValueError(
+            f"`test_size` ({test_size}) must be less than the number of unique dates ({len(sorted_dates)})"
+        )
+
     cutoff = sorted_dates[-test_size]  # Use the date before the test period starts
 
     train_mask = data[date_column] < cutoff

--- a/mmm_eval/core/base_validation_test.py
+++ b/mmm_eval/core/base_validation_test.py
@@ -94,7 +94,7 @@ class BaseValidationTest(ABC):
         logger.info(f"Splitting data into train and test sets for {self.test_name} test")
 
         train_idx, test_idx = split_timeseries_data(
-            data, ValidationTestConstants.TRAIN_TEST_SPLIT_TEST_PROPORTION, date_column=self.date_column
+            data, test_size=ValidationTestConstants.ACCURACY_TEST_SIZE, date_column=self.date_column
         )
         return data[train_idx], data[test_idx]
 
@@ -121,26 +121,36 @@ class BaseValidationTest(ABC):
 
 
 def split_timeseries_data(
-    data: pd.DataFrame, test_proportion: PositiveFloat, date_column: str
+    data: pd.DataFrame,
+    test_size: PositiveInt,
+    date_column: str,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Split data globally based on date.
 
+    Given a timeseries, reserve the last `test_size` unique dates for test set whereas
+    all other dates are used for training.
+
     Arguments:
         data: timeseries data to split, possibly with another index like geography
-        test_proportion: proportion of test data, must be in (0, 1)
         date_column: name of the date column
+        test_size: number of unique dates to reserve for testing.
 
     Returns:
         boolean masks for training and test data respectively
 
+    Raises:
+        ValueError: if `test_size` is invalid.
     """
-    if test_proportion <= 0 or test_proportion >= 1:
-        raise ValueError("`test_proportion` must be in the range (0, 1)")
+    if test_size <= 0:
+        raise ValueError("`test_size` must be greater than 0")
 
     sorted_dates = sorted(data[date_column].unique())
-    # rounding eliminates possibility of floating point precision issues
-    split_idx = int(round(len(sorted_dates) * (1 - test_proportion)))
-    cutoff = sorted_dates[split_idx]
+    
+    # Reserve the last test_size data points for testing
+    if test_size >= len(sorted_dates):
+        raise ValueError(f"`test_size` ({test_size}) must be less than the number of unique dates ({len(sorted_dates)})")
+    
+    cutoff = sorted_dates[-test_size]  # Use the date before the test period starts
 
     train_mask = data[date_column] < cutoff
     test_mask = data[date_column] >= cutoff

--- a/mmm_eval/core/constants.py
+++ b/mmm_eval/core/constants.py
@@ -4,7 +4,7 @@
 class ValidationTestConstants:
     """Constants for the validation tests."""
 
-    TRAIN_TEST_SPLIT_TEST_PROPORTION = 0.2
+    ACCURACY_TEST_SIZE = 8
     RANDOM_STATE = 42
     N_SPLITS = 5
     TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4  # 4 representing a 4 week refresh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mmm-eval"
-version = "0.7.1"
+version = "0.8.0"
 description = "Open-source evaluation of marketing mix model (MMM) performance"
 authors = ["Joseph Kang <joseph.kang@mutinex.co>",
            "Phil Clark <phil.clark@mutinex.co>",

--- a/tests/test_base_validation_test.py
+++ b/tests/test_base_validation_test.py
@@ -130,7 +130,7 @@ class TestBaseValidationTest:
         dates = pd.date_range("2023-01-01", periods=10)
         data = pd.DataFrame({InputDataframeConstants.DATE_COL: dates, "value": range(10)})
 
-        train_mask, test_mask = split_timeseries_data(data, 0.3, InputDataframeConstants.DATE_COL)
+        train_mask, test_mask = split_timeseries_data(data, 3, InputDataframeConstants.DATE_COL)
 
         # Check that masks are boolean arrays
         assert isinstance(train_mask, pd.Series)
@@ -144,24 +144,45 @@ class TestBaseValidationTest:
         # Check that all data is covered
         assert (train_mask | test_mask).all()
 
-        # Check proportions (7 train, 3 test for 0.3 test proportion)
+        # Check proportions (7 train, 3 test for test_size=3)
         assert train_mask.sum() == 7
         assert test_mask.sum() == 3
+
+    def test_split_timeseries_data_exact_test_size(self):
+        """Test that split_timeseries_data reserves exactly test_size dates for testing."""
+        # Create test data with 10 unique dates
+        dates = pd.date_range("2023-01-01", periods=10)
+        data = pd.DataFrame({InputDataframeConstants.DATE_COL: dates, "value": range(10)})
+
+        # Test with different test sizes
+        for test_size in [1, 3, 5, 7]:
+            train_mask, test_mask = split_timeseries_data(data, test_size, InputDataframeConstants.DATE_COL)
+
+            # Count unique dates in test set
+            test_dates = data[test_mask][InputDataframeConstants.DATE_COL].unique()
+            assert len(test_dates) == test_size, f"Expected {test_size} test dates, got {len(test_dates)}"
+
+            # Verify train and test are disjoint
+            train_dates = data[train_mask][InputDataframeConstants.DATE_COL].unique()
+            assert len(set(train_dates) & set(test_dates)) == 0
+
+            # Verify all data is covered
+            assert len(train_dates) + len(test_dates) == len(dates)
 
     def test_split_timeseries_data_edge_cases(self):
         """Test edge cases for split_timeseries_data."""
         dates = pd.date_range("2023-01-01", periods=5)
         data = pd.DataFrame({InputDataframeConstants.DATE_COL: dates, "value": range(5)})
 
-        # Test with very small test proportion
-        train_mask, test_mask = split_timeseries_data(data, 0.1, InputDataframeConstants.DATE_COL)
+        # Test with very small test size
+        train_mask, test_mask = split_timeseries_data(data, 1, InputDataframeConstants.DATE_COL)
         assert train_mask.sum() == 4
         assert test_mask.sum() == 1
 
-        # Test with large test proportion
-        train_mask, test_mask = split_timeseries_data(data, 0.8, InputDataframeConstants.DATE_COL)
-        # With 0.8 test proportion and 5 dates: split_idx = round(5 * 0.2) = 1
-        # cutoff = dates[1] = '2023-01-02', so 1 date < '2023-01-02' and 4 dates >= '2023-01-02'
+        # Test with large test size
+        train_mask, test_mask = split_timeseries_data(data, 4, InputDataframeConstants.DATE_COL)
+        # With test_size=4 and 5 dates: cutoff = dates[-4] = '2023-01-02'
+        # So 1 date < '2023-01-02' and 4 dates >= '2023-01-02'
         assert train_mask.sum() == 1  # 1 date < '2023-01-02'
         assert test_mask.sum() == 4  # 4 dates >= '2023-01-02'
 
@@ -171,9 +192,9 @@ class TestBaseValidationTest:
         dates = pd.to_datetime(["2023-01-01", "2023-01-01", "2023-01-02", "2023-01-02", "2023-01-03"])
         data = pd.DataFrame({InputDataframeConstants.DATE_COL: dates, "value": range(5)})
 
-        train_mask, test_mask = split_timeseries_data(data, 0.4, InputDataframeConstants.DATE_COL)
+        train_mask, test_mask = split_timeseries_data(data, 1, InputDataframeConstants.DATE_COL)
 
-        # Should split based on unique dates (3 unique dates, 0.4 test = 1 test date)
+        # Should split based on unique dates (3 unique dates, test_size=1)
         unique_dates = data[InputDataframeConstants.DATE_COL].unique()
         assert len(unique_dates) == 3
 


### PR DESCRIPTION
For the accuracy test, it makes more sense to split the data with a fixed test set size rather than by proportion, since MMMs are not designed for forecasting at long time horizons and therefore the split shouldn't be determined by the data, but rather fixed. 