### PR TITLE
Implement placebo test by shuffling existing marketing channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] ; 2025-07-21
+
+### Added
+
+- Placebo/falsification test
+
 ## [0.10.0] ; 2025-07-17
 
 ### Added

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -174,34 +174,19 @@ class BaseAdapter(ABC):
         pass
 
     @abstractmethod
-    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-        """Add new channels to the adapter's configuration.
-
-        This method modifies the adapter's configuration to include additional channels.
-        The adapter should not be fitted when this method is called.
-
-        Args:
-            new_channel_names: List of new channel names to add
-
-        Returns:
-            Dictionary mapping channel names to lists of column names that were added for each channel.
-            For example: {"TV_shuffled": ["tv_shuffled_spend", "tv_shuffled_impressions"]}
-
-        """
-        pass
-
-    @abstractmethod
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels.
 
-        This method returns the column names that should be used as primary media regressors
-        for the given channels. This is useful for tests that need to perturb specific channels.
+        This method returns the column names that should be used as primary media
+        regressors for the given channels. This is useful for tests that need to perturb
+        specific channels.
 
         Args:
             channel_names: List of channel names to get regressor columns for
 
         Returns:
-            List of column names that are used as primary media regressors for the given channels
+            List of column names that are used as primary media regressors for the given
+            channels
 
         """
         pass
@@ -211,14 +196,17 @@ class BaseAdapter(ABC):
     ) -> tuple["BaseAdapter", pd.DataFrame]:
         """Template method for adding a placebo channel to the adapter and data.
 
-        This method creates a shuffled version of an existing channel and returns a new adapter
-        configured to use the shuffled channel. The template method pattern ensures consistent
-        behavior across adapters while allowing adapter-specific implementations.
+        This method creates a shuffled version of an existing channel and returns a new
+        adapter configured to use the shuffled channel. The template method pattern
+        ensures consistent behavior across adapters while allowing adapter-specific
+        implementations.
 
         Args:
-            original_channel_name: Name of the original channel to create a placebo version of
+            original_channel_name: Name of the original channel to create a placebo version
+                of
             data_to_shuffle: DataFrame containing the data to add shuffled columns to
-            shuffled_indices: Array of shuffled indices to use for creating the placebo channel
+            shuffled_indices: Array of shuffled indices to use for creating the placebo
+                channel
 
         Returns:
             Tuple of (new_adapter, updated_data) where:
@@ -226,10 +214,10 @@ class BaseAdapter(ABC):
             - updated_data: DataFrame with the shuffled columns added
 
         """
-        # Step 1: Get original columns (subclass-specific)
+        # Step 1: Get original columns to shuffle (subclass-specific)
         original_columns = self._get_original_channel_columns(original_channel_name)
 
-        # Step 2: Create shuffled data (common)
+        # Step 2: Add shuffled columns to the data
         shuffled_channel_name = f"{original_channel_name}_shuffled"
         updated_data = self._create_shuffled_columns(
             data_to_shuffle, original_columns, shuffled_indices, shuffled_channel_name

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -228,22 +228,26 @@ class BaseAdapter(ABC):
         """
         # Step 1: Get original columns (subclass-specific)
         original_columns = self._get_original_channel_columns(original_channel_name)
-        
+
         # Step 2: Create shuffled data (common)
         shuffled_channel_name = f"{original_channel_name}_shuffled"
-        updated_data = self._create_shuffled_columns(data_to_shuffle, original_columns, shuffled_indices, shuffled_channel_name)
-        
+        updated_data = self._create_shuffled_columns(
+            data_to_shuffle, original_columns, shuffled_indices, shuffled_channel_name
+        )
+
         # Step 3: Create new adapter (subclass-specific)
-        new_adapter = self._create_adapter_with_placebo_channel(original_channel_name, shuffled_channel_name, original_columns)
-        
+        new_adapter = self._create_adapter_with_placebo_channel(
+            original_channel_name, shuffled_channel_name, original_columns
+        )
+
         return new_adapter, updated_data
 
     def _create_shuffled_columns(
-        self, 
-        data: pd.DataFrame, 
-        original_columns: dict[str, str], 
-        shuffled_indices: np.ndarray, 
-        shuffled_channel_name: str
+        self,
+        data: pd.DataFrame,
+        original_columns: dict[str, str],
+        shuffled_indices: np.ndarray,
+        shuffled_channel_name: str,
     ) -> pd.DataFrame:
         """Create shuffled columns in the data for the placebo channel.
 
@@ -261,29 +265,30 @@ class BaseAdapter(ABC):
 
         """
         updated_data = data.copy()
-        
+
         for column_type, original_col in original_columns.items():
             if original_col in data.columns:
                 # Let each adapter determine the column naming convention
                 shuffled_col = self._get_shuffled_col_name(shuffled_channel_name, column_type, original_col)
                 updated_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
-        
+
         return updated_data
 
     @abstractmethod
     def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
         """Get the name for a shuffled column based on the adapter's naming convention.
-        
+
         This method should be implemented by each adapter to return the correct column name
         for the shuffled channel according to their naming conventions.
-        
+
         Args:
             shuffled_channel_name: Name of the shuffled channel
             column_type: Type of column (e.g., "spend", "impressions")
             original_col: Original column name
-            
+
         Returns:
             Name for the shuffled column
+
         """
         pass
 

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -248,6 +248,7 @@ class BaseAdapter(ABC):
         """Create shuffled columns in the data for the placebo channel.
 
         This is a common implementation that creates shuffled versions of the original columns.
+        The column naming is handled by each adapter according to their conventions.
 
         Args:
             data: DataFrame to add shuffled columns to
@@ -262,10 +263,29 @@ class BaseAdapter(ABC):
         updated_data = data.copy()
         
         for column_type, original_col in original_columns.items():
-            shuffled_col = f"{shuffled_channel_name}_{column_type}"
-            updated_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
+            if original_col in data.columns:
+                # Let each adapter determine the column naming convention
+                shuffled_col = self._get_shuffled_col_name(shuffled_channel_name, column_type, original_col)
+                updated_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
         
         return updated_data
+
+    @abstractmethod
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+        """Get the name for a shuffled column based on the adapter's naming convention.
+        
+        This method should be implemented by each adapter to return the correct column name
+        for the shuffled channel according to their naming conventions.
+        
+        Args:
+            shuffled_channel_name: Name of the shuffled channel
+            column_type: Type of column (e.g., "spend", "impressions")
+            original_col: Original column name
+            
+        Returns:
+            Name for the shuffled column
+        """
+        pass
 
     @abstractmethod
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -159,3 +159,30 @@ class BaseAdapter(ABC):
 
         """
         pass
+
+    @abstractmethod
+    def copy(self) -> "BaseAdapter":
+        """Create a deep copy of this adapter with all configuration.
+
+        This method creates a complete copy of the adapter including all configuration,
+        but without any fitted state (model, trace, etc.).
+
+        Returns:
+            A new adapter instance with the same configuration as this one
+
+        """
+        pass
+
+    @abstractmethod
+    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+        """Add new channels to the adapter's configuration.
+
+        This method modifies the adapter's configuration to include additional channels.
+        The adapter should not be fitted when this method is called.
+
+        Args:
+            new_channel_columns: List of new channel column names to add
+            new_channel_names: List of new channel names to add (should match new_channel_columns)
+
+        """
+        pass

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -205,3 +205,103 @@ class BaseAdapter(ABC):
 
         """
         pass
+
+    def add_placebo_channel(
+        self, original_channel_name: str, data_to_shuffle: pd.DataFrame, shuffled_indices: np.ndarray
+    ) -> tuple["BaseAdapter", pd.DataFrame]:
+        """Template method for adding a placebo channel to the adapter and data.
+
+        This method creates a shuffled version of an existing channel and returns a new adapter
+        configured to use the shuffled channel. The template method pattern ensures consistent
+        behavior across adapters while allowing adapter-specific implementations.
+
+        Args:
+            original_channel_name: Name of the original channel to create a placebo version of
+            data_to_shuffle: DataFrame containing the data to add shuffled columns to
+            shuffled_indices: Array of shuffled indices to use for creating the placebo channel
+
+        Returns:
+            Tuple of (new_adapter, updated_data) where:
+            - new_adapter: A new adapter instance configured to use the placebo channel
+            - updated_data: DataFrame with the shuffled columns added
+
+        """
+        # Step 1: Get original columns (subclass-specific)
+        original_columns = self._get_original_channel_columns(original_channel_name)
+        
+        # Step 2: Create shuffled data (common)
+        shuffled_channel_name = f"{original_channel_name}_shuffled"
+        updated_data = self._create_shuffled_columns(data_to_shuffle, original_columns, shuffled_indices, shuffled_channel_name)
+        
+        # Step 3: Create new adapter (subclass-specific)
+        new_adapter = self._create_adapter_with_placebo_channel(original_channel_name, shuffled_channel_name, original_columns)
+        
+        return new_adapter, updated_data
+
+    def _create_shuffled_columns(
+        self, 
+        data: pd.DataFrame, 
+        original_columns: dict[str, str], 
+        shuffled_indices: np.ndarray, 
+        shuffled_channel_name: str
+    ) -> pd.DataFrame:
+        """Create shuffled columns in the data for the placebo channel.
+
+        This is a common implementation that creates shuffled versions of the original columns.
+
+        Args:
+            data: DataFrame to add shuffled columns to
+            original_columns: Dictionary mapping column types to original column names
+            shuffled_indices: Array of shuffled indices to use
+            shuffled_channel_name: Name for the new shuffled channel
+
+        Returns:
+            DataFrame with shuffled columns added
+
+        """
+        updated_data = data.copy()
+        
+        for column_type, original_col in original_columns.items():
+            shuffled_col = f"{shuffled_channel_name}_{column_type}"
+            updated_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
+        
+        return updated_data
+
+    @abstractmethod
+    def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
+        """Get the original column names for a channel.
+
+        This method should return a dictionary mapping column types to actual column names
+        in the data. For example:
+        - {"spend": "tv_spend", "impressions": "tv_impressions"} for impressions-based models
+        - {"spend": "tv_spend"} for spend-only models
+
+        Args:
+            channel_name: Name of the channel to get columns for
+
+        Returns:
+            Dictionary mapping column types to actual column names in the data
+
+        """
+        pass
+
+    @abstractmethod
+    def _create_adapter_with_placebo_channel(
+        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+    ) -> "BaseAdapter":
+        """Create a new adapter instance configured to use the placebo channel.
+
+        This method should create a new adapter instance that includes the placebo channel
+        in its configuration. The adapter should be configured to use the shuffled column
+        names that were created in the data.
+
+        Args:
+            original_channel: Name of the original channel
+            shuffled_channel: Name of the new shuffled channel
+            original_columns: Dictionary mapping column types to original column names
+
+        Returns:
+            New adapter instance configured to use the placebo channel
+
+        """
+        pass

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -161,19 +161,6 @@ class BaseAdapter(ABC):
         pass
 
     @abstractmethod
-    def copy(self) -> "BaseAdapter":
-        """Create a deep copy of this adapter with all configuration.
-
-        This method creates a complete copy of the adapter including all configuration,
-        but without any fitted state (model, trace, etc.).
-
-        Returns
-            A new adapter instance with the same configuration as this one
-
-        """
-        pass
-
-    @abstractmethod
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels.
 

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -174,15 +174,14 @@ class BaseAdapter(ABC):
         pass
 
     @abstractmethod
-    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> None:
         """Add new channels to the adapter's configuration.
 
         This method modifies the adapter's configuration to include additional channels.
         The adapter should not be fitted when this method is called.
 
         Args:
-            new_channel_columns: List of new channel column names to add
-            new_channel_names: List of new channel names to add (should match new_channel_columns)
+            new_channel_names: List of new channel names to add
 
         """
         pass

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -167,7 +167,7 @@ class BaseAdapter(ABC):
         This method creates a complete copy of the adapter including all configuration,
         but without any fitted state (model, trace, etc.).
 
-        Returns:
+        Returns
             A new adapter instance with the same configuration as this one
 
         """

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -160,24 +160,6 @@ class BaseAdapter(ABC):
         """
         pass
 
-    @abstractmethod
-    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-        """Get the primary media regressor columns for specific channels.
-
-        This method returns the column names that should be used as primary media
-        regressors for the given channels. This is useful for tests that need to perturb
-        specific channels.
-
-        Args:
-            channel_names: List of channel names to get regressor columns for
-
-        Returns:
-            List of column names that are used as primary media regressors for the given
-            channels
-
-        """
-        pass
-
     def add_placebo_channel(
         self, original_channel_name: str, data_to_shuffle: pd.DataFrame, shuffled_indices: np.ndarray
     ) -> tuple["BaseAdapter", pd.DataFrame]:
@@ -248,6 +230,8 @@ class BaseAdapter(ABC):
 
         return updated_data
 
+    # TODO: add media_channels attribute to PyMC adapter for consistency within Meridian,
+    # and remove the need for this method
     @abstractmethod
     def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on the adapter's naming convention.

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -174,7 +174,7 @@ class BaseAdapter(ABC):
         pass
 
     @abstractmethod
-    def add_channels(self, new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
         """Add new channels to the adapter's configuration.
 
         This method modifies the adapter's configuration to include additional channels.
@@ -182,6 +182,26 @@ class BaseAdapter(ABC):
 
         Args:
             new_channel_names: List of new channel names to add
+
+        Returns:
+            Dictionary mapping channel names to lists of column names that were added for each channel.
+            For example: {"TV_shuffled": ["tv_shuffled_spend", "tv_shuffled_impressions"]}
+
+        """
+        pass
+
+    @abstractmethod
+    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
+        """Get the primary media regressor columns for specific channels.
+
+        This method returns the column names that should be used as primary media regressors
+        for the given channels. This is useful for tests that need to perturb specific channels.
+
+        Args:
+            channel_names: List of channel names to get regressor columns for
+
+        Returns:
+            List of column names that are used as primary media regressors for the given channels
 
         """
         pass

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -202,8 +202,8 @@ class BaseAdapter(ABC):
         implementations.
 
         Args:
-            original_channel_name: Name of the original channel to create a placebo version
-                of
+            original_channel_name: Name of the original channel to create a placebo
+                version of (shuffled to preserve the marginal distribution)
             data_to_shuffle: DataFrame containing the data to add shuffled columns to
             shuffled_indices: Array of shuffled indices to use for creating the placebo
                 channel
@@ -224,9 +224,7 @@ class BaseAdapter(ABC):
         )
 
         # Step 3: Create new adapter (subclass-specific)
-        new_adapter = self._create_adapter_with_placebo_channel(
-            original_channel_name, shuffled_channel_name, original_columns
-        )
+        new_adapter = self._create_adapter_with_placebo_channel(shuffled_channel_name)
 
         return new_adapter, updated_data
 
@@ -239,13 +237,15 @@ class BaseAdapter(ABC):
     ) -> pd.DataFrame:
         """Create shuffled columns in the data for the placebo channel.
 
-        This is a common implementation that creates shuffled versions of the original columns.
-        The column naming is handled by each adapter according to their conventions.
+        This is a common implementation that creates shuffled versions of the original
+        columns. The column naming is handled by each adapter according to their
+        conventions.
 
         Args:
             data: DataFrame to add shuffled columns to
             original_columns: Dictionary mapping column types to original column names
-            shuffled_indices: Array of shuffled indices to use
+            shuffled_indices: Array of shuffled indices to use to transform the original
+                column(s)
             shuffled_channel_name: Name for the new shuffled channel
 
         Returns:
@@ -255,15 +255,14 @@ class BaseAdapter(ABC):
         updated_data = data.copy()
 
         for column_type, original_col in original_columns.items():
-            if original_col in data.columns:
-                # Let each adapter determine the column naming convention
-                shuffled_col = self._get_shuffled_col_name(shuffled_channel_name, column_type, original_col)
-                updated_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
+            # Let each adapter determine the column naming convention
+            shuffled_col = self._get_shuffled_col_name(shuffled_channel_name, column_type)
+            updated_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
 
         return updated_data
 
     @abstractmethod
-    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on the adapter's naming convention.
 
         This method should be implemented by each adapter to return the correct column name
@@ -272,7 +271,6 @@ class BaseAdapter(ABC):
         Args:
             shuffled_channel_name: Name of the shuffled channel
             column_type: Type of column (e.g., "spend", "impressions")
-            original_col: Original column name
 
         Returns:
             Name for the shuffled column
@@ -300,7 +298,8 @@ class BaseAdapter(ABC):
 
     @abstractmethod
     def _create_adapter_with_placebo_channel(
-        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+        self,
+        shuffled_channel: str,
     ) -> "BaseAdapter":
         """Create a new adapter instance configured to use the placebo channel.
 
@@ -309,9 +308,7 @@ class BaseAdapter(ABC):
         names that were created in the data.
 
         Args:
-            original_channel: Name of the original channel
             shuffled_channel: Name of the new shuffled channel
-            original_columns: Dictionary mapping column types to original column names
 
         Returns:
             New adapter instance configured to use the placebo channel

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -331,17 +331,18 @@ class MeridianAdapter(BaseAdapter):
 
         """
         # Find the index of the channel in the media_channels list
-        try:
-            channel_index = self.media_channels.index(channel_name)
-        except ValueError as e:
-            raise ValueError(f"Channel '{channel_name}' not found in media_channels: {self.media_channels}") from e
+        if channel_name not in self.media_channels:
+            raise ValueError(f"Channel '{channel_name}' not found in media_channels: {self.media_channels}")
+        # the integer location of the channel in the media_channels list, assumed to be consistent
+        # across all regressors
+        channel_index = self.media_channels.index(channel_name)
 
         # Build the column mapping based on the regressor type
         columns = {}
 
         # Always include spend column
         if channel_index < len(self.input_data_builder_schema.channel_spend_columns):
-            columns["spend"] = self.input_data_builder_schema.channel_spend_columns[channel_index]
+            columns[PrimaryMediaRegressor.SPEND.value] = self.input_data_builder_schema.channel_spend_columns[channel_index]
 
         # Include impressions column if using impressions regressors
         if (
@@ -349,7 +350,7 @@ class MeridianAdapter(BaseAdapter):
             and self.input_data_builder_schema.channel_impressions_columns
             and channel_index < len(self.input_data_builder_schema.channel_impressions_columns)
         ):
-            columns["impressions"] = self.input_data_builder_schema.channel_impressions_columns[channel_index]
+            columns[PrimaryMediaRegressor.IMPRESSIONS.value] = self.input_data_builder_schema.channel_impressions_columns[channel_index]
 
         # Include reach and frequency columns if using reach/frequency regressors
         if self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -342,7 +342,9 @@ class MeridianAdapter(BaseAdapter):
 
         # Always include spend column
         if channel_index < len(self.input_data_builder_schema.channel_spend_columns):
-            columns[PrimaryMediaRegressor.SPEND.value] = self.input_data_builder_schema.channel_spend_columns[channel_index]
+            columns[PrimaryMediaRegressor.SPEND.value] = self.input_data_builder_schema.channel_spend_columns[
+                channel_index
+            ]
 
         # Include impressions column if using impressions regressors
         if (
@@ -350,7 +352,9 @@ class MeridianAdapter(BaseAdapter):
             and self.input_data_builder_schema.channel_impressions_columns
             and channel_index < len(self.input_data_builder_schema.channel_impressions_columns)
         ):
-            columns[PrimaryMediaRegressor.IMPRESSIONS.value] = self.input_data_builder_schema.channel_impressions_columns[channel_index]
+            columns[PrimaryMediaRegressor.IMPRESSIONS.value] = (
+                self.input_data_builder_schema.channel_impressions_columns[channel_index]
+            )
 
         # Include reach and frequency columns if using reach/frequency regressors
         if self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -430,20 +430,20 @@ class MeridianAdapter(BaseAdapter):
         """
         # Get the current primary media regressor columns
         all_regressor_columns = self.primary_media_regressor_columns
-        
+
         # Find which columns correspond to the requested channels
         # This assumes the order of channels matches the order of columns
         channel_to_column_mapping = {}
         for i, channel in enumerate(self.media_channels):
             if i < len(all_regressor_columns):
                 channel_to_column_mapping[channel] = all_regressor_columns[i]
-        
+
         # Return the columns for the requested channels
         result = []
         for channel_name in channel_names:
             if channel_name in channel_to_column_mapping:
                 result.append(channel_to_column_mapping[channel_name])
-        
+
         return result
 
     def _reset_state(self) -> None:

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -315,6 +315,57 @@ class MeridianAdapter(BaseAdapter):
         """
         return self.media_channels
 
+    def copy(self) -> "MeridianAdapter":
+        """Create a deep copy of this adapter with all configuration.
+
+        Returns:
+            A new MeridianAdapter instance with the same configuration
+
+        """
+        from mmm_eval.configs import MeridianConfig
+        from mmm_eval.adapters.schemas import MeridianInputDataBuilderSchema
+        
+        # Create a deep copy of the input data builder schema
+        new_input_data_builder_schema = MeridianInputDataBuilderSchema(
+            media_channels=self.input_data_builder_schema.media_channels.copy(),
+            channel_spend_columns=self.input_data_builder_schema.channel_spend_columns.copy(),
+            channel_impressions_columns=self.input_data_builder_schema.channel_impressions_columns.copy() if self.input_data_builder_schema.channel_impressions_columns else None,
+            channel_reach_columns=self.input_data_builder_schema.channel_reach_columns.copy() if self.input_data_builder_schema.channel_reach_columns else None,
+            channel_frequency_columns=self.input_data_builder_schema.channel_frequency_columns.copy() if self.input_data_builder_schema.channel_frequency_columns else None,
+            control_columns=self.input_data_builder_schema.control_columns.copy() if self.input_data_builder_schema.control_columns else None,
+            organic_media_columns=self.input_data_builder_schema.organic_media_columns.copy() if self.input_data_builder_schema.organic_media_columns else None,
+            organic_media_channels=self.input_data_builder_schema.organic_media_channels.copy() if self.input_data_builder_schema.organic_media_channels else None,
+            non_media_treatment_columns=self.input_data_builder_schema.non_media_treatment_columns.copy() if self.input_data_builder_schema.non_media_treatment_columns else None,
+        )
+        
+        # Create a new config
+        new_config = MeridianConfig(
+            date_column=self.date_column,
+            input_data_builder_config=new_input_data_builder_schema,
+            model_spec_config=self.config.model_spec_config,
+            sample_posterior_config=self.config.sample_posterior_config,
+        )
+        
+        return MeridianAdapter(new_config)
+
+    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+        """Add new channels to the adapter's configuration.
+
+        Args:
+            new_channel_columns: List of new channel column names to add
+            new_channel_names: List of new channel names to add
+
+        """
+        if self.is_fitted:
+            raise RuntimeError("Cannot add channels to a fitted adapter")
+        
+        # Add to the input data builder schema
+        self.input_data_builder_schema.media_channels.extend(new_channel_names)
+        self.input_data_builder_schema.channel_spend_columns.extend(new_channel_columns)
+        
+        # Update the adapter's channel_spend_columns attribute
+        self.channel_spend_columns.extend(new_channel_columns)
+
     def _reset_state(self) -> None:
         """Reset all stateful attributes to their initial values.
 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -493,6 +493,21 @@ class MeridianAdapter(BaseAdapter):
 
         return columns
 
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+        """Get the name for a shuffled column based on Meridian's naming convention.
+        
+        For Meridian, column names include the column type suffix (e.g., "tv_spend", "tv_impressions").
+        
+        Args:
+            shuffled_channel_name: Name of the shuffled channel
+            column_type: Type of column (e.g., "spend", "impressions")
+            original_col: Original column name
+            
+        Returns:
+            Name for the shuffled column
+        """
+        return f"{shuffled_channel_name}_{column_type}"
+
     def _create_adapter_with_placebo_channel(
         self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
     ) -> "MeridianAdapter":

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -315,46 +315,6 @@ class MeridianAdapter(BaseAdapter):
         """
         return self.media_channels
 
-    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "MeridianAdapter":
-        """Create a copy of this adapter with modified channel configuration.
-
-        Args:
-            new_channel_columns: New list of channel spend column names
-            new_channel_names: New list of channel names (should match new_channel_columns)
-
-        Returns:
-            A new MeridianAdapter instance with modified channel configuration
-
-        """
-        # Create a new config with modified channel configuration
-        from mmm_eval.configs import MeridianConfig
-        from mmm_eval.adapters.schemas import MeridianInputDataBuilderSchema
-        
-        # Create a copy of the input data builder schema with modified channels
-        new_input_data_builder_schema = MeridianInputDataBuilderSchema(
-            media_channels=new_channel_names,
-            channel_spend_columns=new_channel_columns,
-            channel_impressions_columns=self.input_data_builder_schema.channel_impressions_columns,
-            channel_reach_columns=self.input_data_builder_schema.channel_reach_columns,
-            channel_frequency_columns=self.input_data_builder_schema.channel_frequency_columns,
-            control_columns=self.input_data_builder_schema.control_columns,
-            organic_media_columns=self.input_data_builder_schema.organic_media_columns,
-            organic_media_channels=self.input_data_builder_schema.organic_media_channels,
-            non_media_treatment_columns=self.input_data_builder_schema.non_media_treatment_columns,
-        )
-        
-        # Create a new config
-        new_config = MeridianConfig(
-            date_column=self.date_column,
-            input_data_builder_config=new_input_data_builder_schema,
-            model_spec_config=self.config.model_spec_config,
-            sample_posterior_config=self.config.sample_posterior_config,
-        )
-        
-        # Create and return new adapter instance
-        new_adapter = MeridianAdapter(new_config)
-        return new_adapter
-
     def _reset_state(self) -> None:
         """Reset all stateful attributes to their initial values.
 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -316,38 +316,6 @@ class MeridianAdapter(BaseAdapter):
         """
         return self.media_channels
 
-    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-        """Get the primary media regressor columns for specific channels.
-
-        This method returns the subset of primary_media_regressor_columns that correspond
-        to the requested channels.
-
-        Args:
-            channel_names: List of channel names to get regressor columns for
-
-        Returns:
-            List of column names that are used as primary media regressors for the given
-            channels
-
-        """
-        # Get the current primary media regressor columns
-        all_regressor_columns = self.primary_media_regressor_columns
-
-        # Find which columns correspond to the requested channels
-        # This assumes the order of channels matches the order of columns
-        channel_to_column_mapping = {}
-        for i, channel in enumerate(self.media_channels):
-            if i < len(all_regressor_columns):
-                channel_to_column_mapping[channel] = all_regressor_columns[i]
-
-        # Return the columns for the requested channels
-        result = []
-        for channel_name in channel_names:
-            if channel_name in channel_to_column_mapping:
-                result.append(channel_to_column_mapping[channel_name])
-
-        return result
-
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel.
 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -316,67 +316,6 @@ class MeridianAdapter(BaseAdapter):
         """
         return self.media_channels
 
-    def copy(self) -> "MeridianAdapter":
-        """Create a deep copy of this adapter with all configuration.
-
-        Returns
-            A new MeridianAdapter instance with the same configuration
-
-        """
-        # Create a deep copy of the input data builder schema
-        new_input_data_builder_schema = MeridianInputDataBuilderSchema(
-            date_column=self.date_column,
-            response_column=InputDataframeConstants.RESPONSE_COL,
-            media_channels=self.input_data_builder_schema.media_channels.copy(),
-            channel_spend_columns=self.input_data_builder_schema.channel_spend_columns.copy(),
-            channel_impressions_columns=(
-                self.input_data_builder_schema.channel_impressions_columns.copy()
-                if self.input_data_builder_schema.channel_impressions_columns
-                else None
-            ),
-            channel_reach_columns=(
-                self.input_data_builder_schema.channel_reach_columns.copy()
-                if self.input_data_builder_schema.channel_reach_columns
-                else None
-            ),
-            channel_frequency_columns=(
-                self.input_data_builder_schema.channel_frequency_columns.copy()
-                if self.input_data_builder_schema.channel_frequency_columns
-                else None
-            ),
-            control_columns=(
-                self.input_data_builder_schema.control_columns.copy()
-                if self.input_data_builder_schema.control_columns
-                else None
-            ),
-            organic_media_columns=(
-                self.input_data_builder_schema.organic_media_columns.copy()
-                if self.input_data_builder_schema.organic_media_columns
-                else None
-            ),
-            organic_media_channels=(
-                self.input_data_builder_schema.organic_media_channels.copy()
-                if self.input_data_builder_schema.organic_media_channels
-                else None
-            ),
-            non_media_treatment_columns=(
-                self.input_data_builder_schema.non_media_treatment_columns.copy()
-                if self.input_data_builder_schema.non_media_treatment_columns
-                else None
-            ),
-        )
-
-        # Create a new config
-        new_config = MeridianConfig(
-            date_column=self.date_column,
-            revenue_column=self.config.revenue_column,
-            input_data_builder_config=new_input_data_builder_schema,
-            model_spec_config=self.config.model_spec_config,
-            sample_posterior_config=self.config.sample_posterior_config,
-        )
-
-        return MeridianAdapter(new_config)
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels.
 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -377,48 +377,6 @@ class MeridianAdapter(BaseAdapter):
 
         return MeridianAdapter(new_config)
 
-    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-        """Add new channels to the adapter's configuration.
-
-        Args:
-            new_channel_names: List of new channel names to add (e.g., ["TV", "Radio"])
-
-        Returns:
-            Dictionary mapping channel names to lists of column names that were added for each channel.
-            For Meridian, this includes spend columns and potentially impressions columns.
-
-        """
-        if self.is_fitted:
-            raise RuntimeError("Cannot add channels to a fitted adapter")
-
-        # Check if reach/frequency regressor type, not currently supported
-        if self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:
-            raise NotImplementedError("Adding channels is not supported for reach and frequency regressor type")
-
-        # Add to the input data builder schema
-        self.input_data_builder_schema.media_channels.extend(new_channel_names)
-
-        # Add spend columns for new channels
-        spend_columns = [f"{channel.lower()}_spend" for channel in new_channel_names]
-        self.input_data_builder_schema.channel_spend_columns.extend(spend_columns)
-        self.channel_spend_columns.extend(spend_columns)
-
-        # Add impressions columns if using impressions regressors
-        if self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS:
-            impressions_columns = [f"{channel.lower()}_impressions" for channel in new_channel_names]
-            if self.input_data_builder_schema.channel_impressions_columns:
-                self.input_data_builder_schema.channel_impressions_columns.extend(impressions_columns)
-
-        # Return the column names that correspond to the new channels
-        added_columns = {}
-        for channel_name in new_channel_names:
-            channel_columns = [f"{channel_name.lower()}_spend"]
-            if self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS:
-                channel_columns.append(f"{channel_name.lower()}_impressions")
-            added_columns[channel_name] = channel_columns
-
-        return added_columns
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels.
 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -466,45 +466,50 @@ class MeridianAdapter(BaseAdapter):
         # Find the index of the channel in the media_channels list
         try:
             channel_index = self.media_channels.index(channel_name)
-        except ValueError:
-            raise ValueError(f"Channel '{channel_name}' not found in media_channels: {self.media_channels}")
+        except ValueError as e:
+            raise ValueError(f"Channel '{channel_name}' not found in media_channels: {self.media_channels}") from e
 
         # Build the column mapping based on the regressor type
         columns = {}
-        
+
         # Always include spend column
         if channel_index < len(self.input_data_builder_schema.channel_spend_columns):
             columns["spend"] = self.input_data_builder_schema.channel_spend_columns[channel_index]
-        
+
         # Include impressions column if using impressions regressors
-        if (self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS and 
-            self.input_data_builder_schema.channel_impressions_columns and
-            channel_index < len(self.input_data_builder_schema.channel_impressions_columns)):
+        if (
+            self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS
+            and self.input_data_builder_schema.channel_impressions_columns
+            and channel_index < len(self.input_data_builder_schema.channel_impressions_columns)
+        ):
             columns["impressions"] = self.input_data_builder_schema.channel_impressions_columns[channel_index]
-        
+
         # Include reach and frequency columns if using reach/frequency regressors
-        if (self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY):
-            if (self.input_data_builder_schema.channel_reach_columns and
-                channel_index < len(self.input_data_builder_schema.channel_reach_columns)):
+        if self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:
+            if self.input_data_builder_schema.channel_reach_columns and channel_index < len(
+                self.input_data_builder_schema.channel_reach_columns
+            ):
                 columns["reach"] = self.input_data_builder_schema.channel_reach_columns[channel_index]
-            if (self.input_data_builder_schema.channel_frequency_columns and
-                channel_index < len(self.input_data_builder_schema.channel_frequency_columns)):
+            if self.input_data_builder_schema.channel_frequency_columns and channel_index < len(
+                self.input_data_builder_schema.channel_frequency_columns
+            ):
                 columns["frequency"] = self.input_data_builder_schema.channel_frequency_columns[channel_index]
 
         return columns
 
     def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
         """Get the name for a shuffled column based on Meridian's naming convention.
-        
+
         For Meridian, column names include the column type suffix (e.g., "tv_spend", "tv_impressions").
-        
+
         Args:
             shuffled_channel_name: Name of the shuffled channel
             column_type: Type of column (e.g., "spend", "impressions")
             original_col: Original column name
-            
+
         Returns:
             Name for the shuffled column
+
         """
         return f"{shuffled_channel_name}_{column_type}"
 

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -387,7 +387,8 @@ class MeridianAdapter(BaseAdapter):
             channel_names: List of channel names to get regressor columns for
 
         Returns:
-            List of column names that are used as primary media regressors for the given channels
+            List of column names that are used as primary media regressors for the given
+            channels
 
         """
         # Get the current primary media regressor columns
@@ -411,8 +412,9 @@ class MeridianAdapter(BaseAdapter):
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel.
 
-        For Meridian, this returns the actual column names in the data for the given channel.
-        The mapping depends on the regressor type (spend-only, impressions, or reach/frequency).
+        For Meridian, this returns the actual column names in the data for the given
+        channel. The mapping depends on the regressor type (spend-only, impressions, or
+        reach/frequency).
 
         Args:
             channel_name: Name of the channel to get columns for
@@ -455,7 +457,7 @@ class MeridianAdapter(BaseAdapter):
 
         return columns
 
-    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on Meridian's naming convention.
 
         For Meridian, column names include the column type suffix (e.g., "tv_spend", "tv_impressions").
@@ -463,7 +465,6 @@ class MeridianAdapter(BaseAdapter):
         Args:
             shuffled_channel_name: Name of the shuffled channel
             column_type: Type of column (e.g., "spend", "impressions")
-            original_col: Original column name
 
         Returns:
             Name for the shuffled column
@@ -472,7 +473,8 @@ class MeridianAdapter(BaseAdapter):
         return f"{shuffled_channel_name}_{column_type}"
 
     def _create_adapter_with_placebo_channel(
-        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+        self,
+        shuffled_channel: str,
     ) -> "MeridianAdapter":
         """Create a new adapter instance configured to use the placebo channel.
 
@@ -480,9 +482,7 @@ class MeridianAdapter(BaseAdapter):
         appropriate column lists in the input data builder schema.
 
         Args:
-            original_channel: Name of the original channel
             shuffled_channel: Name of the new shuffled channel
-            original_columns: Dictionary mapping column types to original column names
 
         Returns:
             New MeridianAdapter instance configured to use the placebo channel

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -393,7 +393,11 @@ class MeridianAdapter(BaseAdapter):
 
         # Store original column lists to determine what was added
         original_spend_columns = self.input_data_builder_schema.channel_spend_columns.copy()
-        original_impressions_columns = self.input_data_builder_schema.channel_impressions_columns.copy() if self.input_data_builder_schema.channel_impressions_columns else []
+        original_impressions_columns = (
+            self.input_data_builder_schema.channel_impressions_columns.copy()
+            if self.input_data_builder_schema.channel_impressions_columns
+            else []
+        )
 
         # Add to the input data builder schema
         self.input_data_builder_schema.media_channels.extend(new_channel_names)
@@ -413,20 +417,25 @@ class MeridianAdapter(BaseAdapter):
         added_columns = {}
         for channel_name in new_channel_names:
             channel_columns = []
-            
+
             # Add spend column
             spend_col = f"{channel_name.lower()}_spend"
-            if spend_col in self.input_data_builder_schema.channel_spend_columns and spend_col not in original_spend_columns:
+            if (
+                spend_col in self.input_data_builder_schema.channel_spend_columns
+                and spend_col not in original_spend_columns
+            ):
                 channel_columns.append(spend_col)
-            
+
             # Add impressions column if applicable
             if self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS:
                 impressions_col = f"{channel_name.lower()}_impressions"
-                if (self.input_data_builder_schema.channel_impressions_columns and 
-                    impressions_col in self.input_data_builder_schema.channel_impressions_columns and 
-                    impressions_col not in original_impressions_columns):
+                if (
+                    self.input_data_builder_schema.channel_impressions_columns
+                    and impressions_col in self.input_data_builder_schema.channel_impressions_columns
+                    and impressions_col not in original_impressions_columns
+                ):
                     channel_columns.append(impressions_col)
-            
+
             added_columns[channel_name] = channel_columns
 
         return added_columns
@@ -446,20 +455,20 @@ class MeridianAdapter(BaseAdapter):
         """
         # Get the current primary media regressor columns
         all_regressor_columns = self.primary_media_regressor_columns
-        
+
         # Find which columns correspond to the requested channels
         # This assumes the order of channels matches the order of columns
         channel_to_column_mapping = {}
         for i, channel in enumerate(self.media_channels):
             if i < len(all_regressor_columns):
                 channel_to_column_mapping[channel] = all_regressor_columns[i]
-        
+
         # Return the columns for the requested channels
         result = []
         for channel_name in channel_names:
             if channel_name in channel_to_column_mapping:
                 result.append(channel_to_column_mapping[channel_name])
-        
+
         return result
 
     def _reset_state(self) -> None:

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -318,7 +318,7 @@ class MeridianAdapter(BaseAdapter):
     def copy(self) -> "MeridianAdapter":
         """Create a deep copy of this adapter with all configuration.
 
-        Returns:
+        Returns
             A new MeridianAdapter instance with the same configuration
 
         """
@@ -326,15 +326,43 @@ class MeridianAdapter(BaseAdapter):
         new_input_data_builder_schema = MeridianInputDataBuilderSchema(
             media_channels=self.input_data_builder_schema.media_channels.copy(),
             channel_spend_columns=self.input_data_builder_schema.channel_spend_columns.copy(),
-            channel_impressions_columns=self.input_data_builder_schema.channel_impressions_columns.copy() if self.input_data_builder_schema.channel_impressions_columns else None,
-            channel_reach_columns=self.input_data_builder_schema.channel_reach_columns.copy() if self.input_data_builder_schema.channel_reach_columns else None,
-            channel_frequency_columns=self.input_data_builder_schema.channel_frequency_columns.copy() if self.input_data_builder_schema.channel_frequency_columns else None,
-            control_columns=self.input_data_builder_schema.control_columns.copy() if self.input_data_builder_schema.control_columns else None,
-            organic_media_columns=self.input_data_builder_schema.organic_media_columns.copy() if self.input_data_builder_schema.organic_media_columns else None,
-            organic_media_channels=self.input_data_builder_schema.organic_media_channels.copy() if self.input_data_builder_schema.organic_media_channels else None,
-            non_media_treatment_columns=self.input_data_builder_schema.non_media_treatment_columns.copy() if self.input_data_builder_schema.non_media_treatment_columns else None,
+            channel_impressions_columns=(
+                self.input_data_builder_schema.channel_impressions_columns.copy()
+                if self.input_data_builder_schema.channel_impressions_columns
+                else None
+            ),
+            channel_reach_columns=(
+                self.input_data_builder_schema.channel_reach_columns.copy()
+                if self.input_data_builder_schema.channel_reach_columns
+                else None
+            ),
+            channel_frequency_columns=(
+                self.input_data_builder_schema.channel_frequency_columns.copy()
+                if self.input_data_builder_schema.channel_frequency_columns
+                else None
+            ),
+            control_columns=(
+                self.input_data_builder_schema.control_columns.copy()
+                if self.input_data_builder_schema.control_columns
+                else None
+            ),
+            organic_media_columns=(
+                self.input_data_builder_schema.organic_media_columns.copy()
+                if self.input_data_builder_schema.organic_media_columns
+                else None
+            ),
+            organic_media_channels=(
+                self.input_data_builder_schema.organic_media_channels.copy()
+                if self.input_data_builder_schema.organic_media_channels
+                else None
+            ),
+            non_media_treatment_columns=(
+                self.input_data_builder_schema.non_media_treatment_columns.copy()
+                if self.input_data_builder_schema.non_media_treatment_columns
+                else None
+            ),
         )
-        
+
         # Create a new config
         new_config = MeridianConfig(
             date_column=self.date_column,
@@ -342,7 +370,7 @@ class MeridianAdapter(BaseAdapter):
             model_spec_config=self.config.model_spec_config,
             sample_posterior_config=self.config.sample_posterior_config,
         )
-        
+
         return MeridianAdapter(new_config)
 
     def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
@@ -358,11 +386,11 @@ class MeridianAdapter(BaseAdapter):
         """
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
-        
+
         # Check if reach/frequency regressor type is not supported
         if self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:
             raise NotImplementedError("Adding channels is not supported for reach and frequency regressor type")
-        
+
         # Add to the input data builder schema
         self.input_data_builder_schema.media_channels.extend(new_channel_names)
 
@@ -374,18 +402,18 @@ class MeridianAdapter(BaseAdapter):
         added_columns = {}
         for channel_name in new_channel_names:
             channel_columns = [f"{channel_name.lower()}_spend"]
-            
+
             # Determine column names based on regressor type
             if self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS:
                 # For impressions-based models, add both spend and impressions columns
                 impressions_columns = [f"{channel_name.lower()}_impressions"]
                 channel_columns.extend(impressions_columns)
-                
+
                 if self.input_data_builder_schema.channel_impressions_columns:
                     self.input_data_builder_schema.channel_impressions_columns.extend(impressions_columns)
-            
+
             added_columns[channel_name] = channel_columns
-        
+
         return added_columns
 
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
@@ -405,7 +433,7 @@ class MeridianAdapter(BaseAdapter):
         """
         if self.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:
             return []  # Not supported
-        
+
         if self.primary_media_regressor_type == PrimaryMediaRegressor.IMPRESSIONS:
             # Return impressions columns for the specified channels
             return [f"{channel.lower()}_impressions" for channel in channel_names]

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -303,6 +303,58 @@ class MeridianAdapter(BaseAdapter):
             return self.input_data_builder_schema.channel_impressions_columns
         return self.channel_spend_columns
 
+    def get_channel_names(self) -> list[str]:
+        """Get the channel names that would be used as the index in get_channel_roi results.
+
+        For Meridian, this returns the media_channels which are the human-readable
+        channel names used in the ROI results.
+
+        Returns
+            List of channel names
+
+        """
+        return self.media_channels
+
+    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "MeridianAdapter":
+        """Create a copy of this adapter with modified channel configuration.
+
+        Args:
+            new_channel_columns: New list of channel spend column names
+            new_channel_names: New list of channel names (should match new_channel_columns)
+
+        Returns:
+            A new MeridianAdapter instance with modified channel configuration
+
+        """
+        # Create a new config with modified channel configuration
+        from mmm_eval.configs import MeridianConfig
+        from mmm_eval.adapters.schemas import MeridianInputDataBuilderSchema
+        
+        # Create a copy of the input data builder schema with modified channels
+        new_input_data_builder_schema = MeridianInputDataBuilderSchema(
+            media_channels=new_channel_names,
+            channel_spend_columns=new_channel_columns,
+            channel_impressions_columns=self.input_data_builder_schema.channel_impressions_columns,
+            channel_reach_columns=self.input_data_builder_schema.channel_reach_columns,
+            channel_frequency_columns=self.input_data_builder_schema.channel_frequency_columns,
+            control_columns=self.input_data_builder_schema.control_columns,
+            organic_media_columns=self.input_data_builder_schema.organic_media_columns,
+            organic_media_channels=self.input_data_builder_schema.organic_media_channels,
+            non_media_treatment_columns=self.input_data_builder_schema.non_media_treatment_columns,
+        )
+        
+        # Create a new config
+        new_config = MeridianConfig(
+            date_column=self.date_column,
+            input_data_builder_config=new_input_data_builder_schema,
+            model_spec_config=self.config.model_spec_config,
+            sample_posterior_config=self.config.sample_posterior_config,
+        )
+        
+        # Create and return new adapter instance
+        new_adapter = MeridianAdapter(new_config)
+        return new_adapter
+
     def _reset_state(self) -> None:
         """Reset all stateful attributes to their initial values.
 
@@ -482,15 +534,3 @@ class MeridianAdapter(BaseAdapter):
         for channel, roi in zip(self.media_channels, rois_per_channel, strict=False):
             rois[channel] = float(roi)
         return pd.Series(rois)
-
-    def get_channel_names(self) -> list[str]:
-        """Get the channel names that would be used as the index in get_channel_roi results.
-
-        For Meridian, this returns the media_channels which are the human-readable
-        channel names used in the ROI results.
-
-        Returns
-            List of channel names
-
-        """
-        return self.media_channels

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -144,7 +144,6 @@ class PyMCAdapter(BaseAdapter):
         """
         # Create updated model config with the new channel
         updated_model_kwargs = self._original_model_kwargs.copy()
-        # shuffled_channel_with_suffix = shuffled_channel + "_spend"
         updated_model_kwargs["channel_columns"] = self._original_channel_spend_columns + [shuffled_channel]
 
         # Create schema objects from the updated configuration

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -92,34 +92,6 @@ class PyMCAdapter(BaseAdapter):
         """
         return self.channel_spend_columns
 
-    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "PyMCAdapter":
-        """Create a copy of this adapter with modified channel configuration.
-
-        Args:
-            new_channel_columns: New list of channel spend column names
-            new_channel_names: New list of channel names (should match new_channel_columns)
-
-        Returns:
-            A new PyMCAdapter instance with modified channel configuration
-
-        """
-        # Create a new config with modified channel columns
-        from mmm_eval.configs import PyMCConfig
-        
-        # Create a copy of the original config
-        new_config = PyMCConfig(
-            date_column=self.date_column,
-            channel_columns=new_channel_columns,
-            control_columns=self.control_columns,
-            pymc_model_config_dict=self._original_model_kwargs.copy(),
-            fit_config_dict=self.fit_kwargs.copy(),
-            predict_config_dict=self.predict_kwargs.copy(),
-        )
-        
-        # Create and return new adapter instance
-        new_adapter = PyMCAdapter(new_config)
-        return new_adapter
-
     def fit(self, data: pd.DataFrame) -> None:
         """Fit the model and compute ROIs.
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -104,7 +104,7 @@ class PyMCAdapter(BaseAdapter):
         # Create schema objects from the current configuration
         model_config = PyMCModelSchema(**self._original_model_kwargs)
         fit_config = PyMCFitSchema(**self.fit_kwargs)
-        
+
         # Create a new config with copied values
         new_config = PyMCConfig(
             pymc_model_config=model_config,
@@ -172,16 +172,17 @@ class PyMCAdapter(BaseAdapter):
 
     def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
         """Get the name for a shuffled column based on PyMC's naming convention.
-        
+
         For PyMC, channel names are the same as column names, so we just use the shuffled channel name.
-        
+
         Args:
             shuffled_channel_name: Name of the shuffled channel
             column_type: Type of column (e.g., "spend", "impressions")
             original_col: Original column name
-            
+
         Returns:
             Name for the shuffled column
+
         """
         return shuffled_channel_name
 
@@ -204,13 +205,13 @@ class PyMCAdapter(BaseAdapter):
         """
         # Create updated model config with the new channel
         updated_model_kwargs = self._original_model_kwargs.copy()
-        #shuffled_channel_with_suffix = shuffled_channel + "_spend"
+        # shuffled_channel_with_suffix = shuffled_channel + "_spend"
         updated_model_kwargs["channel_columns"] = self._original_channel_spend_columns + [shuffled_channel]
-        
+
         # Create schema objects from the updated configuration
         model_config = PyMCModelSchema(**updated_model_kwargs)
         fit_config = PyMCFitSchema(**self.fit_kwargs)
-        
+
         # Create a new config with the shuffled channel added
         new_config = PyMCConfig(
             pymc_model_config=model_config,

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -94,20 +94,6 @@ class PyMCAdapter(BaseAdapter):
         """
         return self.channel_spend_columns
 
-    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-        """Get the primary media regressor columns for specific channels.
-
-        For PyMC, the primary media regressor columns are the same as the channel names.
-
-        Args:
-            channel_names: List of channel names to get regressor columns for
-
-        Returns:
-            List of column names that are used as primary media regressors for the given channels
-
-        """
-        return channel_names
-
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel.
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -170,7 +170,7 @@ class PyMCAdapter(BaseAdapter):
         # PyMC only uses spend as the primary regressor
         return {"spend": channel_name}
 
-    def _get_shuffled_column_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
         """Get the name for a shuffled column based on PyMC's naming convention.
         
         For PyMC, channel names are the same as column names, so we just use the shuffled channel name.
@@ -204,6 +204,7 @@ class PyMCAdapter(BaseAdapter):
         """
         # Create updated model config with the new channel
         updated_model_kwargs = self._original_model_kwargs.copy()
+        #shuffled_channel_with_suffix = shuffled_channel + "_spend"
         updated_model_kwargs["channel_columns"] = self._original_channel_spend_columns + [shuffled_channel]
         
         # Create schema objects from the updated configuration

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -146,15 +146,14 @@ class PyMCAdapter(BaseAdapter):
         # PyMC only uses spend as the primary regressor
         return {"spend": channel_name}
 
-    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on PyMC's naming convention.
 
         For PyMC, channel names are the same as column names, so we just use the shuffled channel name.
 
         Args:
             shuffled_channel_name: Name of the shuffled channel
-            column_type: Type of column (e.g., "spend", "impressions")
-            original_col: Original column name
+            column_type: Type of column (e.g., "spend", "impressions"). Unused for PyMC.
 
         Returns:
             Name for the shuffled column
@@ -163,7 +162,8 @@ class PyMCAdapter(BaseAdapter):
         return shuffled_channel_name
 
     def _create_adapter_with_placebo_channel(
-        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+        self,
+        shuffled_channel: str,
     ) -> "PyMCAdapter":
         """Create a new adapter instance configured to use the placebo channel.
 
@@ -171,9 +171,7 @@ class PyMCAdapter(BaseAdapter):
         channel_columns list.
 
         Args:
-            original_channel: Name of the original channel
             shuffled_channel: Name of the new shuffled channel
-            original_columns: Dictionary mapping column types to original column names
 
         Returns:
             New PyMCAdapter instance configured to use the placebo channel

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -92,6 +92,34 @@ class PyMCAdapter(BaseAdapter):
         """
         return self.channel_spend_columns
 
+    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "PyMCAdapter":
+        """Create a copy of this adapter with modified channel configuration.
+
+        Args:
+            new_channel_columns: New list of channel spend column names
+            new_channel_names: New list of channel names (should match new_channel_columns)
+
+        Returns:
+            A new PyMCAdapter instance with modified channel configuration
+
+        """
+        # Create a new config with modified channel columns
+        from mmm_eval.configs import PyMCConfig
+        
+        # Create a copy of the original config
+        new_config = PyMCConfig(
+            date_column=self.date_column,
+            channel_columns=new_channel_columns,
+            control_columns=self.control_columns,
+            pymc_model_config_dict=self._original_model_kwargs.copy(),
+            fit_config_dict=self.fit_kwargs.copy(),
+            predict_config_dict=self.predict_kwargs.copy(),
+        )
+        
+        # Create and return new adapter instance
+        new_adapter = PyMCAdapter(new_config)
+        return new_adapter
+
     def fit(self, data: pd.DataFrame) -> None:
         """Fit the model and compute ROIs.
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -99,8 +99,6 @@ class PyMCAdapter(BaseAdapter):
             A new PyMCAdapter instance with the same configuration
 
         """
-        from mmm_eval.configs import PyMCConfig
-        
         # Create a new config with copied values
         new_config = PyMCConfig(
             date_column=self.date_column,
@@ -113,11 +111,15 @@ class PyMCAdapter(BaseAdapter):
         
         return PyMCAdapter(new_config)
 
-    def add_channels(self, new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
         """Add new channels to the adapter's configuration.
 
         Args:
             new_channel_names: List of new channel names to add
+
+        Returns:
+            Dictionary mapping channel names to lists of column names that were added for each channel.
+            For PyMC, channel names are the same as column names.
 
         """
         if self.is_fitted:
@@ -126,10 +128,26 @@ class PyMCAdapter(BaseAdapter):
         # For PyMC, channel names are the same as column names
         # Add to the current channel lists
         self.channel_spend_columns.extend(new_channel_names)
-        self._media_channels.extend(new_channel_names)
         
         # Update the original lists as well (for future copy operations)
         self._original_channel_spend_columns.extend(new_channel_names)
+        
+        # Return mapping of channel names to column names (they're the same for PyMC)
+        return {channel_name: [channel_name] for channel_name in new_channel_names}
+
+    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
+        """Get the primary media regressor columns for specific channels.
+
+        For PyMC, the primary media regressor columns are the same as the channel names.
+
+        Args:
+            channel_names: List of channel names to get regressor columns for
+
+        Returns:
+            List of column names that are used as primary media regressors for the given channels
+
+        """
+        return channel_names
 
     def fit(self, data: pd.DataFrame) -> None:
         """Fit the model and compute ROIs.

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -94,27 +94,6 @@ class PyMCAdapter(BaseAdapter):
         """
         return self.channel_spend_columns
 
-    def copy(self) -> "PyMCAdapter":
-        """Create a deep copy of this adapter with all configuration.
-
-        Returns
-            A new PyMCAdapter instance with the same configuration
-
-        """
-        # Create schema objects from the current configuration
-        model_config = PyMCModelSchema(**self._original_model_kwargs)
-        fit_config = PyMCFitSchema(**self.fit_kwargs)
-
-        # Create a new config with copied values
-        new_config = PyMCConfig(
-            pymc_model_config=model_config,
-            fit_config=fit_config,
-            revenue_column=self.config.revenue_column,
-            response_column=self.config.response_column,
-        )
-
-        return PyMCAdapter(new_config)
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels.
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -95,7 +95,7 @@ class PyMCAdapter(BaseAdapter):
     def copy(self) -> "PyMCAdapter":
         """Create a deep copy of this adapter with all configuration.
 
-        Returns:
+        Returns
             A new PyMCAdapter instance with the same configuration
 
         """
@@ -108,7 +108,7 @@ class PyMCAdapter(BaseAdapter):
             fit_config_dict=self.fit_kwargs.copy(),
             predict_config_dict=self.predict_kwargs.copy(),
         )
-        
+
         return PyMCAdapter(new_config)
 
     def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
@@ -124,14 +124,14 @@ class PyMCAdapter(BaseAdapter):
         """
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
-        
+
         # For PyMC, channel names are the same as column names
         # Add to the current channel lists
         self.channel_spend_columns.extend(new_channel_names)
-        
+
         # Update the original lists as well (for future copy operations)
         self._original_channel_spend_columns.extend(new_channel_names)
-        
+
         # Return mapping of channel names to column names (they're the same for PyMC)
         return {channel_name: [channel_name] for channel_name in new_channel_names}
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -115,30 +115,6 @@ class PyMCAdapter(BaseAdapter):
 
         return PyMCAdapter(new_config)
 
-    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-        """Add new channels to the adapter's configuration.
-
-        Args:
-            new_channel_names: List of new channel names to add
-
-        Returns:
-            Dictionary mapping channel names to lists of column names that were added for each channel.
-            For PyMC, channel names are the same as column names.
-
-        """
-        if self.is_fitted:
-            raise RuntimeError("Cannot add channels to a fitted adapter")
-
-        # For PyMC, channel names are the same as column names
-        # Add to the current channel lists
-        self.channel_spend_columns.extend(new_channel_names)
-
-        # Update the original lists as well (for future copy operations)
-        self._original_channel_spend_columns.extend(new_channel_names)
-
-        # Return mapping of channel names to column names (they're the same for PyMC)
-        return {channel_name: [channel_name] for channel_name in new_channel_names}
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels.
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -92,6 +92,45 @@ class PyMCAdapter(BaseAdapter):
         """
         return self.channel_spend_columns
 
+    def copy(self) -> "PyMCAdapter":
+        """Create a deep copy of this adapter with all configuration.
+
+        Returns:
+            A new PyMCAdapter instance with the same configuration
+
+        """
+        from mmm_eval.configs import PyMCConfig
+        
+        # Create a new config with copied values
+        new_config = PyMCConfig(
+            date_column=self.date_column,
+            channel_columns=self._original_channel_spend_columns.copy(),
+            control_columns=self.control_columns.copy(),
+            pymc_model_config_dict=self._original_model_kwargs.copy(),
+            fit_config_dict=self.fit_kwargs.copy(),
+            predict_config_dict=self.predict_kwargs.copy(),
+        )
+        
+        return PyMCAdapter(new_config)
+
+    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+        """Add new channels to the adapter's configuration.
+
+        Args:
+            new_channel_columns: List of new channel column names to add
+            new_channel_names: List of new channel names to add
+
+        """
+        if self.is_fitted:
+            raise RuntimeError("Cannot add channels to a fitted adapter")
+        
+        # Add to the current channel lists
+        self.channel_spend_columns.extend(new_channel_columns)
+        self._media_channels.extend(new_channel_names)
+        
+        # Update the original lists as well (for future copy operations)
+        self._original_channel_spend_columns.extend(new_channel_columns)
+
     def fit(self, data: pd.DataFrame) -> None:
         """Fit the model and compute ROIs.
 

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -113,23 +113,23 @@ class PyMCAdapter(BaseAdapter):
         
         return PyMCAdapter(new_config)
 
-    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> None:
         """Add new channels to the adapter's configuration.
 
         Args:
-            new_channel_columns: List of new channel column names to add
             new_channel_names: List of new channel names to add
 
         """
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
         
+        # For PyMC, channel names are the same as column names
         # Add to the current channel lists
-        self.channel_spend_columns.extend(new_channel_columns)
+        self.channel_spend_columns.extend(new_channel_names)
         self._media_channels.extend(new_channel_names)
         
         # Update the original lists as well (for future copy operations)
-        self._original_channel_spend_columns.extend(new_channel_columns)
+        self._original_channel_spend_columns.extend(new_channel_names)
 
     def fit(self, data: pd.DataFrame) -> None:
         """Fit the model and compute ROIs.

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -149,6 +149,52 @@ class PyMCAdapter(BaseAdapter):
         """
         return channel_names
 
+    def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
+        """Get the original column names for a channel.
+
+        For PyMC, this is straightforward since channel names are the same as column names.
+        PyMC only uses spend as the primary regressor.
+
+        Args:
+            channel_name: Name of the channel to get columns for
+
+        Returns:
+            Dictionary mapping column types to actual column names in the data
+
+        """
+        # For PyMC, channel names are the same as column names
+        # PyMC only uses spend as the primary regressor
+        return {"spend": channel_name}
+
+    def _create_adapter_with_placebo_channel(
+        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+    ) -> "PyMCAdapter":
+        """Create a new adapter instance configured to use the placebo channel.
+
+        For PyMC, this creates a new adapter with the shuffled channel added to the
+        channel_columns list.
+
+        Args:
+            original_channel: Name of the original channel
+            shuffled_channel: Name of the new shuffled channel
+            original_columns: Dictionary mapping column types to original column names
+
+        Returns:
+            New PyMCAdapter instance configured to use the placebo channel
+
+        """
+        # Create a new config with the shuffled channel added
+        new_config = PyMCConfig(
+            date_column=self.date_column,
+            channel_columns=self._original_channel_spend_columns + [shuffled_channel],
+            control_columns=self.control_columns.copy(),
+            pymc_model_config_dict=self._original_model_kwargs.copy(),
+            fit_config_dict=self.fit_kwargs.copy(),
+            predict_config_dict=self.predict_kwargs.copy(),
+        )
+
+        return PyMCAdapter(new_config)
+
     def fit(self, data: pd.DataFrame) -> None:
         """Fit the model and compute ROIs.
 

--- a/mmm_eval/core/validation_test_orchestrator.py
+++ b/mmm_eval/core/validation_test_orchestrator.py
@@ -14,8 +14,8 @@ from mmm_eval.core.validation_tests import (
     HoldoutAccuracyTest,
     InSampleAccuracyTest,
     PerturbationTest,
-    RefreshStabilityTest,
     PlaceboTest,
+    RefreshStabilityTest,
 )
 from mmm_eval.core.validation_tests_models import ValidationTestNames
 

--- a/mmm_eval/core/validation_test_orchestrator.py
+++ b/mmm_eval/core/validation_test_orchestrator.py
@@ -71,7 +71,7 @@ class ValidationTestOrchestrator:
             logger.info(f"Running test: {test_name}")
             test_instance = self.tests[test_name](adapter.date_column)
             test_result = test_instance.run(adapter, data)
-            #test_result = test_instance.run_with_error_handling(adapter, data)
+            # test_result = test_instance.run_with_error_handling(adapter, data)
             results[test_name] = test_result
 
         return ValidationResults(results)

--- a/mmm_eval/core/validation_test_orchestrator.py
+++ b/mmm_eval/core/validation_test_orchestrator.py
@@ -15,6 +15,7 @@ from mmm_eval.core.validation_tests import (
     InSampleAccuracyTest,
     PerturbationTest,
     RefreshStabilityTest,
+    PlaceboTest,
 )
 from mmm_eval.core.validation_tests_models import ValidationTestNames
 
@@ -36,6 +37,7 @@ class ValidationTestOrchestrator:
             ValidationTestNames.CROSS_VALIDATION: CrossValidationTest,
             ValidationTestNames.REFRESH_STABILITY: RefreshStabilityTest,
             ValidationTestNames.PERTURBATION: PerturbationTest,
+            ValidationTestNames.PLACEBO: PlaceboTest,
         }
 
     def _get_all_test_names(self) -> list[ValidationTestNames]:

--- a/mmm_eval/core/validation_test_orchestrator.py
+++ b/mmm_eval/core/validation_test_orchestrator.py
@@ -70,8 +70,7 @@ class ValidationTestOrchestrator:
         for test_name in test_names:
             logger.info(f"Running test: {test_name}")
             test_instance = self.tests[test_name](adapter.date_column)
-            test_result = test_instance.run(adapter, data)
-            # test_result = test_instance.run_with_error_handling(adapter, data)
+            test_result = test_instance.run_with_error_handling(adapter, data)
             results[test_name] = test_result
 
         return ValidationResults(results)

--- a/mmm_eval/core/validation_test_orchestrator.py
+++ b/mmm_eval/core/validation_test_orchestrator.py
@@ -70,7 +70,8 @@ class ValidationTestOrchestrator:
         for test_name in test_names:
             logger.info(f"Running test: {test_name}")
             test_instance = self.tests[test_name](adapter.date_column)
-            test_result = test_instance.run_with_error_handling(adapter, data)
+            test_result = test_instance.run(adapter, data)
+            #test_result = test_instance.run_with_error_handling(adapter, data)
             results[test_name] = test_result
 
         return ValidationResults(results)

--- a/mmm_eval/core/validation_test_results.py
+++ b/mmm_eval/core/validation_test_results.py
@@ -13,6 +13,7 @@ from mmm_eval.metrics.metric_models import (
     CrossValidationMetricResults,
     PerturbationMetricResults,
     RefreshStabilityMetricResults,
+    PlaceboMetricResults,
 )
 
 
@@ -32,6 +33,7 @@ class ValidationTestResult:
             | CrossValidationMetricResults
             | RefreshStabilityMetricResults
             | PerturbationMetricResults
+            | PlaceboMetricResults
         ),
     ):
         """Initialize test results.

--- a/mmm_eval/core/validation_test_results.py
+++ b/mmm_eval/core/validation_test_results.py
@@ -12,8 +12,8 @@ from mmm_eval.metrics.metric_models import (
     AccuracyMetricResults,
     CrossValidationMetricResults,
     PerturbationMetricResults,
-    RefreshStabilityMetricResults,
     PlaceboMetricResults,
+    RefreshStabilityMetricResults,
 )
 
 

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -399,10 +399,7 @@ class PlaceboTest(BaseValidationTest):
         
         # Create a copy of the adapter and add the shuffled channel
         adapter_copy = adapter.copy()
-        adapter_copy.add_channels(
-            new_channel_columns=[shuffled_channel_col],
-            new_channel_names=[shuffled_channel_name]
-        )
+        adapter_copy.add_channels([shuffled_channel_name])
         
         # Fit the copied adapter and check ROI
         adapter_copy.fit(shuffled_data)

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -398,9 +398,7 @@ class PlaceboTest(BaseValidationTest):
 
         # Use the new template method to add placebo channel
         adapter_copy, shuffled_data = adapter.add_placebo_channel(
-            original_channel_name=original_channel,
-            data_to_shuffle=data,
-            shuffled_indices=shuffled_indices
+            original_channel_name=original_channel, data_to_shuffle=data, shuffled_indices=shuffled_indices
         )
 
         # Fit the copied adapter and check ROI

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -397,37 +397,17 @@ class PlaceboTest(BaseValidationTest):
         # Shuffle the original channel data
         shuffled_data[shuffled_channel_col] = data[original_channel_col].sample(frac=1.0, random_state=self.rng).values
         
-        # Store original adapter state
-        original_channel_spend_columns = adapter.channel_spend_columns.copy()
-        original_media_channels = adapter.media_channels.copy()
+        # Create a copy of the adapter and add the shuffled channel
+        adapter_copy = adapter.copy()
+        adapter_copy.add_channels(
+            new_channel_columns=[shuffled_channel_col],
+            new_channel_names=[shuffled_channel_name]
+        )
         
-        try:
-            # Temporarily modify adapter to include shuffled channel
-            adapter.channel_spend_columns = original_channel_spend_columns + [shuffled_channel_col]
-            
-            # For adapters that store media_channels as a property, we need to modify it
-            # This is a bit of a hack, but it's the cleanest way without adding new methods
-            if hasattr(adapter, '_media_channels'):
-                adapter._media_channels = original_media_channels + [shuffled_channel_name]
-            elif hasattr(adapter, 'input_data_builder_schema'):
-                # For Meridian adapter, modify the schema
-                adapter.input_data_builder_schema.media_channels = original_media_channels + [shuffled_channel_name]
-                adapter.input_data_builder_schema.channel_spend_columns = adapter.channel_spend_columns
-            
-            # Fit modified adapter and check ROI
-            adapter.fit(shuffled_data)
-            rois = adapter.get_channel_roi()
-            shuffled_roi = rois[shuffled_channel_name]
-            
-        finally:
-            # Restore original adapter state
-            adapter.channel_spend_columns = original_channel_spend_columns
-            if hasattr(adapter, '_media_channels'):
-                adapter._media_channels = original_media_channels
-            elif hasattr(adapter, 'input_data_builder_schema'):
-                # For Meridian adapter, restore the schema
-                adapter.input_data_builder_schema.media_channels = original_media_channels
-                adapter.input_data_builder_schema.channel_spend_columns = original_channel_spend_columns
+        # Fit the copied adapter and check ROI
+        adapter_copy.fit(shuffled_data)
+        rois = adapter_copy.get_channel_roi()
+        shuffled_roi = rois[shuffled_channel_name]
         
         # Create metric results
         test_scores = PlaceboMetricResults(

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -25,10 +25,10 @@ from mmm_eval.metrics.metric_models import (
     CrossValidationMetricResults,
     PerturbationMetricNames,
     PerturbationMetricResults,
-    RefreshStabilityMetricNames,
-    RefreshStabilityMetricResults,
     PlaceboMetricNames,
     PlaceboMetricResults,
+    RefreshStabilityMetricNames,
+    RefreshStabilityMetricResults,
 )
 
 logger = logging.getLogger(__name__)
@@ -387,36 +387,36 @@ class PlaceboTest(BaseValidationTest):
         """Run the placebo test."""
         # Select a random channel to shuffle
         original_channel = self.rng.choice(adapter.media_channels)
-        
+
         # Create shuffled data
         shuffled_data = data.copy()
-        
+
         # Create a copy of the adapter and add the shuffled channel
         adapter_copy = adapter.copy()
         shuffled_channel_name = f"{original_channel}_shuffled"
         added_columns = adapter_copy.add_channels([shuffled_channel_name])
-        
+
         # Get the columns that were added for the shuffled channel
         shuffled_channel_columns = added_columns[shuffled_channel_name]
-        
+
         # Get the primary media regressor columns for the original channel
         original_regressor_columns = adapter.get_primary_media_regressor_columns_for_channels([original_channel])
-        
+
         # Create shuffled indices for consistent shuffling across related columns
         shuffled_indices = np.arange(len(data))
         self.rng.shuffle(shuffled_indices)
-        
+
         # Shuffle the original channel data and add to shuffled data
         for i, original_col in enumerate(original_regressor_columns):
             if original_col in data.columns:
                 shuffled_col = shuffled_channel_columns[i]
                 shuffled_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
-        
+
         # Fit the copied adapter and check ROI
         adapter_copy.fit(shuffled_data)
         rois = adapter_copy.get_channel_roi()
         shuffled_roi = rois[shuffled_channel_name]
-        
+
         # Create metric results
         test_scores = PlaceboMetricResults(
             shuffled_channel_roi=shuffled_roi,

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -385,8 +385,19 @@ class PlaceboTest(BaseValidationTest):
     def run(self, adapter: BaseAdapter, data: pd.DataFrame) -> ValidationTestResult:
         """Run the placebo test."""
         if adapter.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:
-            # FIXME: throw warning and return test result with null values
-            pass
+            logger.warning(
+                "Placebo test skipped: Reach and frequency regressor type not supported for placebo testing."
+            )
+            # Return NaN results indicating the test was not run
+            test_scores = PlaceboMetricResults(
+                shuffled_channel_roi=np.nan,
+                shuffled_channel_name="test_skipped",
+            )
+            return ValidationTestResult(
+                test_name=ValidationTestNames.PLACEBO,
+                metric_names=PlaceboMetricNames.to_list(),
+                test_scores=test_scores,
+            )
 
         # Select a random channel to shuffle
         original_channel = self.rng.choice(adapter.media_channels)

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -385,36 +385,28 @@ class PlaceboTest(BaseValidationTest):
 
     def run(self, adapter: BaseAdapter, data: pd.DataFrame) -> ValidationTestResult:
         """Run the placebo test."""
+        if adapter.primary_media_regressor_type == PrimaryMediaRegressor.REACH_AND_FREQUENCY:
+            # FIXME: throw warning and return test result with null values
+            pass
+
         # Select a random channel to shuffle
         original_channel = self.rng.choice(adapter.media_channels)
-
-        # Create shuffled data
-        shuffled_data = data.copy()
-
-        # Create a copy of the adapter and add the shuffled channel
-        adapter_copy = adapter.copy()
-        shuffled_channel_name = f"{original_channel}_shuffled"
-        added_columns = adapter_copy.add_channels([shuffled_channel_name])
-
-        # Get the columns that were added for the shuffled channel
-        shuffled_channel_columns = added_columns[shuffled_channel_name]
-
-        # Get the primary media regressor columns for the original channel
-        original_regressor_columns = adapter.get_primary_media_regressor_columns_for_channels([original_channel])
 
         # Create shuffled indices for consistent shuffling across related columns
         shuffled_indices = np.arange(len(data))
         self.rng.shuffle(shuffled_indices)
 
-        # Shuffle the original channel data and add to shuffled data
-        for i, original_col in enumerate(original_regressor_columns):
-            if original_col in data.columns:
-                shuffled_col = shuffled_channel_columns[i]
-                shuffled_data[shuffled_col] = data[original_col].iloc[shuffled_indices].values
+        # Use the new template method to add placebo channel
+        adapter_copy, shuffled_data = adapter.add_placebo_channel(
+            original_channel_name=original_channel,
+            data_to_shuffle=data,
+            shuffled_indices=shuffled_indices
+        )
 
         # Fit the copied adapter and check ROI
         adapter_copy.fit(shuffled_data)
         rois = adapter_copy.get_channel_roi()
+        shuffled_channel_name = f"{original_channel}_shuffled"
         shuffled_roi = rois[shuffled_channel_name]
 
         # Create metric results

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -400,7 +400,7 @@ class PlaceboTest(BaseValidationTest):
             )
 
         # Select a random channel to shuffle
-        original_channel = self.rng.choice(adapter.media_channels)
+        original_channel = str(self.rng.choice(adapter.media_channels))
 
         # Create shuffled indices for consistent shuffling across related columns
         shuffled_indices = np.arange(len(data))

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -374,8 +374,7 @@ class PlaceboTest(BaseValidationTest):
     """Validation test for detecting spurious correlations in the MMM framework.
 
     This test creates a shuffled version of an existing media channel and tests whether
-    the model assigns a low ROI to this spurious feature. A good model should assign
-    an ROI less than 0.2 to the shuffled channel.
+    the model assigns a low ROI to this spurious feature.
     """
 
     @property

--- a/mmm_eval/core/validation_tests_models.py
+++ b/mmm_eval/core/validation_tests_models.py
@@ -14,6 +14,7 @@ class ValidationTestNames(StrEnum):
     CROSS_VALIDATION = "cross_validation"
     REFRESH_STABILITY = "refresh_stability"
     PERTURBATION = "perturbation"
+    PLACEBO = "placebo"
 
     @classmethod
     def all_tests(cls) -> list["ValidationTestNames"]:

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -11,8 +11,8 @@ from mmm_eval.metrics.threshold_constants import (
     AccuracyThresholdConstants,
     CrossValidationThresholdConstants,
     PerturbationThresholdConstants,
-    RefreshStabilityThresholdConstants,
     PlaceboThresholdConstants,
+    RefreshStabilityThresholdConstants,
 )
 
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -12,6 +12,7 @@ from mmm_eval.metrics.threshold_constants import (
     CrossValidationThresholdConstants,
     PerturbationThresholdConstants,
     RefreshStabilityThresholdConstants,
+    PlaceboThresholdConstants,
 )
 
 
@@ -90,6 +91,12 @@ class PerturbationMetricNames(MetricNamesBase):
     """Define the names of the perturbation metrics."""
 
     PERCENTAGE_CHANGE = "percentage_change"
+
+
+class PlaceboMetricNames(MetricNamesBase):
+    """Define the names of the placebo test metrics."""
+
+    SHUFFLED_CHANNEL_ROI = "shuffled_channel_roi"
 
 
 class TestResultDFAttributes(MetricNamesBase):
@@ -358,5 +365,35 @@ class PerturbationMetricResults(MetricResults):
                 channel_series=self.percentage_change_for_each_channel,
                 metric_name=PerturbationMetricNames.PERCENTAGE_CHANGE,
             )
+        )
+        return self.add_pass_fail_column(df)
+
+
+class PlaceboMetricResults(MetricResults):
+    """Define the results of the placebo test metrics."""
+
+    shuffled_channel_roi: float
+    shuffled_channel_name: str
+
+    def _check_metric_threshold(self, metric_name: str, metric_value: float) -> bool:
+        """Check if a specific placebo test metric passes its threshold."""
+        if metric_name == PlaceboMetricNames.SHUFFLED_CHANNEL_ROI.value:
+            return bool(metric_value <= PlaceboThresholdConstants.ROI_THRESHOLD)
+        else:
+            valid_metric_names = PlaceboMetricNames.to_list()
+            raise InvalidMetricNameException(
+                f"Invalid metric name: {metric_name}. Valid metric names are: {valid_metric_names}"
+            )
+
+    def to_df(self) -> pd.DataFrame:
+        """Convert the placebo test metric results to a long DataFrame format."""
+        df = pd.DataFrame(
+            [
+                self._create_single_metric_dataframe_row(
+                    general_metric_name=PlaceboMetricNames.SHUFFLED_CHANNEL_ROI.value,
+                    specific_metric_name=f"{PlaceboMetricNames.SHUFFLED_CHANNEL_ROI.value}_{self.shuffled_channel_name}",
+                    metric_value=self.shuffled_channel_roi,
+                ),
+            ]
         )
         return self.add_pass_fail_column(df)

--- a/mmm_eval/metrics/threshold_constants.py
+++ b/mmm_eval/metrics/threshold_constants.py
@@ -32,3 +32,9 @@ class PerturbationThresholdConstants:
     """Constants for the perturbation threshold."""
 
     PERCENTAGE_CHANGE = 8.0
+
+
+class PlaceboThresholdConstants:
+    """Constants for the placebo test threshold."""
+
+    ROI_THRESHOLD = 0.2

--- a/mmm_eval/metrics/threshold_constants.py
+++ b/mmm_eval/metrics/threshold_constants.py
@@ -37,4 +37,5 @@ class PerturbationThresholdConstants:
 class PlaceboThresholdConstants:
     """Constants for the placebo test threshold."""
 
-    ROI_THRESHOLD = 0.2
+    # means $1 spend -> $0.50 return (50% loss)
+    ROI_THRESHOLD = -50.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mmm-eval"
-version = "0.10.0"
+version = "0.11.0"
 description = "Open-source evaluation of marketing mix model (MMM) performance"
 authors = ["Joseph Kang <joseph.kang@mutinex.co>",
            "Phil Clark <phil.clark@mutinex.co>",

--- a/tests/test_adapters/test_meridian.py
+++ b/tests/test_adapters/test_meridian.py
@@ -735,7 +735,8 @@ class TestMeridianAdapter:
         # No date filtering
         result = adapter.get_channel_roi()
         assert isinstance(result, pd.Series)
-        assert result["tv"] == 5.0
+        # ROI calculation: 100 * (roi - 1) = 100 * (5.0 - 1) = 400.0
+        assert result["tv"] == 400.0
         # With date filtering
         result = adapter.get_channel_roi(start_date=pd.Timestamp("2023-01-03"))
         assert isinstance(result, pd.Series)

--- a/tests/test_cli/test_evaluate.py
+++ b/tests/test_cli/test_evaluate.py
@@ -101,13 +101,6 @@ def test_cli_scenarios(tmp_path, cli_args, expected_exit_code, test_name):
     runner = CliRunner()
     result = runner.invoke(main, formatted_args)
 
-    # Print debug info
-    print(f"Test: {test_name}")
-    print(f"Exit code: {result.exit_code}")
-    print(f"Output: {result.output}")
-    if result.exception:
-        print(f"Exception: {result.exception}")
-
     # Check that the CLI command returned the expected exit code
     assert (
         result.exit_code == expected_exit_code

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -170,21 +170,6 @@ def test_cli_e2e_meridian(tmp_path):
             # Don't try to set media_channels directly since it's a property
             return new_adapter
 
-        def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-            """Add new channels to the adapter's configuration."""
-            if self.is_fitted:
-                raise RuntimeError("Cannot add channels to a fitted adapter")
-
-            # For mock adapter, assume channel names are the same as column names
-            added_columns = {}
-            for channel_name in new_channel_names:
-                self.channel_spend_columns.append(channel_name)
-                # Add to the underlying schema instead of trying to set the property
-                self.input_data_builder_schema.media_channels.append(channel_name)
-                added_columns[channel_name] = [channel_name]
-
-            return added_columns
-
         def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
             """Get the primary media regressor columns for specific channels."""
             return channel_names

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -163,10 +163,6 @@ def test_cli_e2e_meridian(tmp_path):
             """Get the channel names that would be used as the index in get_channel_roi results."""
             return self.media_channels
 
-        def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-            """Get the primary media regressor columns for specific channels."""
-            return channel_names
-
         def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
             """Get the original column names for a channel."""
             # For mock adapter, map channel names to their actual column names

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -151,6 +151,7 @@ def test_cli_e2e_meridian(tmp_path):
         def primary_media_regressor_type(self):
             """Return the type of primary media regressors."""
             from mmm_eval.adapters.base import PrimaryMediaRegressor
+
             return PrimaryMediaRegressor.SPEND
 
         @property
@@ -173,7 +174,7 @@ def test_cli_e2e_meridian(tmp_path):
             """Add new channels to the adapter's configuration."""
             if self.is_fitted:
                 raise RuntimeError("Cannot add channels to a fitted adapter")
-            
+
             # For mock adapter, assume channel names are the same as column names
             added_columns = {}
             for channel_name in new_channel_names:
@@ -181,7 +182,7 @@ def test_cli_e2e_meridian(tmp_path):
                 # Add to the underlying schema instead of trying to set the property
                 self.input_data_builder_schema.media_channels.append(channel_name)
                 added_columns[channel_name] = [channel_name]
-            
+
             return added_columns
 
         def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -163,13 +163,6 @@ def test_cli_e2e_meridian(tmp_path):
             """Get the channel names that would be used as the index in get_channel_roi results."""
             return self.media_channels
 
-        def copy(self) -> "MockMeridianAdapter":
-            """Create a deep copy of this adapter with all configuration."""
-            new_adapter = MockMeridianAdapter(self.config)
-            new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
-            # Don't try to set media_channels directly since it's a property
-            return new_adapter
-
         def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
             """Get the primary media regressor columns for specific channels."""
             return channel_names

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -176,16 +176,18 @@ def test_cli_e2e_meridian(tmp_path):
 
         def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
             """Get the original column names for a channel."""
-            # For mock adapter, assume channel names are the same as column names
-            return {"spend": channel_name}
+            # For mock adapter, map channel names to their actual column names
+            # The data has columns like "Channel0_spend", "Channel1_spend"
+            return {"spend": f"{channel_name}_spend"}
 
-        def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+        def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
             """Get the name for a shuffled column based on the mock adapter's naming convention."""
             # For mock adapter, use the same convention as Meridian (with suffix)
             return f"{shuffled_channel_name}_{column_type}"
 
         def _create_adapter_with_placebo_channel(
-            self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+            self,
+            shuffled_channel: str,
         ) -> "MockMeridianAdapter":
             """Create a new adapter instance configured to use the placebo channel."""
             new_adapter = MockMeridianAdapter(self.config)

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -111,6 +111,23 @@ class MockAdapter(BaseAdapter):
         """Get the primary media regressor columns for specific channels."""
         return channel_names
 
+    def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
+        """Get the original column names for a channel."""
+        # For mock adapter, assume channel names are the same as column names
+        return {"spend": channel_name}
+
+    def _create_adapter_with_placebo_channel(
+        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+    ) -> "MockAdapter":
+        """Create a new adapter instance configured to use the placebo channel."""
+        new_adapter = MockAdapter(
+            primary_media_regressor_type=self._primary_media_regressor_type,
+            primary_media_regressor_columns=self._primary_media_regressor_columns.copy(),
+            channel_spend_columns=self.channel_spend_columns + [f"{shuffled_channel}_spend"] if self.channel_spend_columns else None,
+            media_channels=self._media_channels + [shuffled_channel] if self._media_channels else None,
+        )
+        return new_adapter
+
 
 @pytest.fixture
 def sample_data():

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -95,7 +95,7 @@ class MockAdapter(BaseAdapter):
         """Add new channels to the adapter."""
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
-        
+
         # For mock adapter, assume channel names are the same as column names
         added_columns = {}
         for channel_name in new_channel_names:
@@ -104,7 +104,7 @@ class MockAdapter(BaseAdapter):
             if self._media_channels is not None:
                 self._media_channels.append(channel_name)
             added_columns[channel_name] = [channel_name]
-        
+
         return added_columns
 
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -128,7 +128,9 @@ class MockAdapter(BaseAdapter):
         new_adapter = MockAdapter(
             primary_media_regressor_type=self._primary_media_regressor_type,
             primary_media_regressor_columns=self._primary_media_regressor_columns.copy(),
-            channel_spend_columns=self.channel_spend_columns + [f"{shuffled_channel}_spend"] if self.channel_spend_columns else None,
+            channel_spend_columns=(
+                self.channel_spend_columns + [f"{shuffled_channel}_spend"] if self.channel_spend_columns else None
+            ),
             media_channels=self._media_channels + [shuffled_channel] if self._media_channels else None,
         )
         return new_adapter

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -81,16 +81,6 @@ class MockAdapter(BaseAdapter):
         """Get the channel names that would be used as the index in get_channel_roi results."""
         return self.media_channels
 
-    def copy(self) -> "MockAdapter":
-        """Create a deep copy of this adapter."""
-        new_adapter = MockAdapter(
-            primary_media_regressor_type=self._primary_media_regressor_type,
-            primary_media_regressor_columns=self._primary_media_regressor_columns.copy(),
-            channel_spend_columns=self.channel_spend_columns.copy() if self.channel_spend_columns else None,
-            media_channels=self._media_channels.copy() if self._media_channels else None,
-        )
-        return new_adapter
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
         return channel_names

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -91,7 +91,6 @@ class MockAdapter(BaseAdapter):
         )
         return new_adapter
 
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
         return channel_names
@@ -101,13 +100,14 @@ class MockAdapter(BaseAdapter):
         # For mock adapter, assume channel names are the same as column names
         return {"spend": channel_name}
 
-    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on the mock adapter's naming convention."""
         # For mock adapter, use the same convention as Meridian (with suffix)
         return f"{shuffled_channel_name}_{column_type}"
 
     def _create_adapter_with_placebo_channel(
-        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+        self,
+        shuffled_channel: str,
     ) -> "MockAdapter":
         """Create a new adapter instance configured to use the placebo channel."""
         new_adapter = MockAdapter(

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -91,21 +91,6 @@ class MockAdapter(BaseAdapter):
         )
         return new_adapter
 
-    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-        """Add new channels to the adapter."""
-        if self.is_fitted:
-            raise RuntimeError("Cannot add channels to a fitted adapter")
-
-        # For mock adapter, assume channel names are the same as column names
-        added_columns = {}
-        for channel_name in new_channel_names:
-            if self.channel_spend_columns is not None:
-                self.channel_spend_columns.append(channel_name)
-            if self._media_channels is not None:
-                self._media_channels.append(channel_name)
-            added_columns[channel_name] = [channel_name]
-
-        return added_columns
 
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -116,6 +116,11 @@ class MockAdapter(BaseAdapter):
         # For mock adapter, assume channel names are the same as column names
         return {"spend": channel_name}
 
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+        """Get the name for a shuffled column based on the mock adapter's naming convention."""
+        # For mock adapter, use the same convention as Meridian (with suffix)
+        return f"{shuffled_channel_name}_{column_type}"
+
     def _create_adapter_with_placebo_channel(
         self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
     ) -> "MockAdapter":

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -91,16 +91,25 @@ class MockAdapter(BaseAdapter):
         )
         return new_adapter
 
-    def add_channels(self, new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
         """Add new channels to the adapter."""
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
         
         # For mock adapter, assume channel names are the same as column names
-        if self.channel_spend_columns is not None:
-            self.channel_spend_columns.extend(new_channel_names)
-        if self._media_channels is not None:
-            self._media_channels.extend(new_channel_names)
+        added_columns = {}
+        for channel_name in new_channel_names:
+            if self.channel_spend_columns is not None:
+                self.channel_spend_columns.append(channel_name)
+            if self._media_channels is not None:
+                self._media_channels.append(channel_name)
+            added_columns[channel_name] = [channel_name]
+        
+        return added_columns
+
+    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
+        """Get the primary media regressor columns for specific channels."""
+        return channel_names
 
 
 @pytest.fixture

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -81,6 +81,26 @@ class MockAdapter(BaseAdapter):
         """Get the channel names that would be used as the index in get_channel_roi results."""
         return self.media_channels
 
+    def copy(self) -> "MockAdapter":
+        """Create a deep copy of this adapter."""
+        new_adapter = MockAdapter(
+            primary_media_regressor_type=self._primary_media_regressor_type,
+            primary_media_regressor_columns=self._primary_media_regressor_columns.copy(),
+            channel_spend_columns=self.channel_spend_columns.copy() if self.channel_spend_columns else None,
+            media_channels=self._media_channels.copy() if self._media_channels else None,
+        )
+        return new_adapter
+
+    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+        """Add new channels to the adapter."""
+        if self.is_fitted:
+            raise RuntimeError("Cannot add channels to a fitted adapter")
+        
+        if self.channel_spend_columns is not None:
+            self.channel_spend_columns.extend(new_channel_columns)
+        if self._media_channels is not None:
+            self._media_channels.extend(new_channel_names)
+
 
 @pytest.fixture
 def sample_data():

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -81,10 +81,6 @@ class MockAdapter(BaseAdapter):
         """Get the channel names that would be used as the index in get_channel_roi results."""
         return self.media_channels
 
-    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-        """Get the primary media regressor columns for specific channels."""
-        return channel_names
-
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel."""
         # For mock adapter, assume channel names are the same as column names

--- a/tests/test_validation_tests/test_perturbation.py
+++ b/tests/test_validation_tests/test_perturbation.py
@@ -91,13 +91,14 @@ class MockAdapter(BaseAdapter):
         )
         return new_adapter
 
-    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> None:
         """Add new channels to the adapter."""
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
         
+        # For mock adapter, assume channel names are the same as column names
         if self.channel_spend_columns is not None:
-            self.channel_spend_columns.extend(new_channel_columns)
+            self.channel_spend_columns.extend(new_channel_names)
         if self._media_channels is not None:
             self._media_channels.extend(new_channel_names)
 

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -1,0 +1,139 @@
+"""Unit tests for PlaceboTest."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mmm_eval.adapters.base import BaseAdapter, PrimaryMediaRegressor
+from mmm_eval.core.validation_tests import PlaceboTest
+from mmm_eval.core.validation_tests_models import ValidationTestNames
+from mmm_eval.data.constants import InputDataframeConstants
+from mmm_eval.metrics.metric_models import PlaceboMetricResults
+
+
+class MockAdapter(BaseAdapter):
+    """Mock adapter for testing PlaceboTest."""
+
+    def __init__(self, date_column: str = "date"):
+        """Initialize mock adapter."""
+        self.date_column = date_column
+        self.channel_spend_columns = ["tv_spend", "radio_spend"]
+        self._media_channels = ["TV", "Radio"]
+        self.is_fitted = False
+        self._roi_results = None
+
+    @property
+    def media_channels(self) -> list[str]:
+        """Return the channel names used by this adapter."""
+        return self._media_channels
+
+    def fit(self, data: pd.DataFrame) -> None:
+        """Mock fit method."""
+        self.is_fitted = True
+        # Set ROI results based on the data columns
+        if "tv_spend_shuffled" in data.columns:
+            # If shuffled channel is present, give it a low ROI
+            self._roi_results = pd.Series({"TV": 1.5, "Radio": 2.0, "TV_shuffled": 0.1})
+        else:
+            self._roi_results = pd.Series({"TV": 1.5, "Radio": 2.0})
+
+    def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
+        """Mock predict method."""
+        return np.array([1.0, 2.0, 3.0])
+
+    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray:
+        """Mock fit_and_predict method."""
+        return np.array([1.0, 2.0])
+
+    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> np.ndarray:
+        """Mock fit_and_predict_in_sample method."""
+        return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def get_channel_roi(self, start_date=None, end_date=None) -> pd.Series:
+        """Mock get_channel_roi method."""
+        if not self.is_fitted:
+            raise RuntimeError("Model must be fit before computing ROI")
+        return self._roi_results
+
+    def get_channel_names(self) -> list[str]:
+        """Mock get_channel_names method."""
+        return self.media_channels
+
+    @property
+    def primary_media_regressor_type(self) -> PrimaryMediaRegressor:
+        """Return the type of primary media regressors."""
+        return PrimaryMediaRegressor.SPEND
+
+    @property
+    def primary_media_regressor_columns(self) -> list[str]:
+        """Return the primary media regressor columns."""
+        return self.channel_spend_columns
+
+    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "MockAdapter":
+        """Create a copy with modified channels."""
+        new_adapter = MockAdapter(self.date_column)
+        new_adapter.channel_spend_columns = new_channel_columns
+        new_adapter._media_channels = new_channel_names
+        return new_adapter
+
+
+class TestPlaceboTest:
+    """Test cases for PlaceboTest."""
+
+    def test_placebo_test_creation(self):
+        """Test that PlaceboTest can be created."""
+        test = PlaceboTest(date_column="date")
+        assert test.test_name == ValidationTestNames.PLACEBO
+
+    def test_placebo_test_run(self):
+        """Test that PlaceboTest runs successfully."""
+        # Create test data
+        dates = pd.date_range("2023-01-01", periods=10, freq="D")
+        data = pd.DataFrame({
+            "date": dates,
+            "response": np.random.randn(10) + 100,
+            "revenue": np.random.randn(10) + 1000,
+            "tv_spend": np.random.randn(10) + 50,
+            "radio_spend": np.random.randn(10) + 30,
+        })
+
+        # Create adapter and test
+        adapter = MockAdapter(date_column="date")
+        test = PlaceboTest(date_column="date")
+        
+        # Run the test
+        result = test.run(adapter, data)
+        
+        # Verify the result
+        assert result.test_name == ValidationTestNames.PLACEBO
+        assert isinstance(result.test_scores, PlaceboMetricResults)
+        assert result.test_scores.shuffled_channel_roi == 0.1
+        assert result.test_scores.shuffled_channel_name.endswith("_shuffled")
+        assert len(result.metric_names) == 1
+        assert "shuffled_channel_roi" in result.metric_names
+
+    def test_placebo_test_metric_threshold(self):
+        """Test that the metric threshold checking works correctly."""
+        # Create metric results with low ROI (should pass)
+        results = PlaceboMetricResults(
+            shuffled_channel_roi=0.1,
+            shuffled_channel_name="TV_shuffled"
+        )
+        
+        # Test threshold checking
+        assert results._check_metric_threshold("shuffled_channel_roi", 0.1) is True
+        assert results._check_metric_threshold("shuffled_channel_roi", 0.3) is False
+
+    def test_placebo_test_dataframe_output(self):
+        """Test that the metric results can be converted to DataFrame."""
+        results = PlaceboMetricResults(
+            shuffled_channel_roi=0.1,
+            shuffled_channel_name="TV_shuffled"
+        )
+        
+        df = results.to_df()
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 1
+        assert "shuffled_channel_roi" in df["general_metric_name"].values
+        assert df["metric_value"].iloc[0] == 0.1
+        assert df["metric_pass"].iloc[0] == True  # noqa: E712 

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -76,12 +76,13 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> None:
         """Add new channels to the adapter."""
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
         
-        self.channel_spend_columns.extend(new_channel_columns)
+        # For mock adapter, assume channel names are the same as column names
+        self.channel_spend_columns.extend(new_channel_names)
         self._media_channels.extend(new_channel_names)
 
 

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -71,13 +71,6 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
-    def copy(self) -> "MockAdapter":
-        """Create a deep copy of this adapter."""
-        new_adapter = MockAdapter(self.date_column)
-        new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
-        new_adapter._media_channels = self._media_channels.copy()
-        return new_adapter
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
         return channel_names
@@ -216,12 +209,6 @@ class TestPlaceboTest:
 
             def get_channel_names(self) -> list[str]:
                 return self.media_channels
-
-            def copy(self) -> "MeridianStyleAdapter":
-                new_adapter = MeridianStyleAdapter()
-                new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
-                new_adapter._media_channels = self._media_channels.copy()
-                return new_adapter
 
             def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
                 return [f"{channel.lower()}_impressions" for channel in channel_names]

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -78,7 +78,6 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
         return channel_names
@@ -92,13 +91,14 @@ class MockAdapter(BaseAdapter):
         }
         return channel_mapping.get(channel_name, {"spend": f"{channel_name.lower()}_spend"})
 
-    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on the mock adapter's naming convention."""
         # For mock adapter, use the same convention as Meridian (with suffix)
         return f"{shuffled_channel_name}_{column_type}"
 
     def _create_adapter_with_placebo_channel(
-        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+        self,
+        shuffled_channel: str,
     ) -> "MockAdapter":
         """Create a new adapter instance configured to use the placebo channel."""
         new_adapter = MockAdapter(self.date_column)
@@ -238,13 +238,14 @@ class TestPlaceboTest:
                     {"spend": f"{channel_name.lower()}_spend", "impressions": f"{channel_name.lower()}_impressions"},
                 )
 
-            def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+            def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
                 """Get the name for a shuffled column based on the mock adapter's naming convention."""
                 # For this mock adapter, use the same convention as Meridian (with suffix)
                 return f"{shuffled_channel_name}_{column_type}"
 
             def _create_adapter_with_placebo_channel(
-                self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+                self,
+                shuffled_channel: str,
             ) -> "MeridianStyleAdapter":
                 """Create a new adapter instance configured to use the placebo channel."""
                 new_adapter = MeridianStyleAdapter()

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -69,13 +69,6 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
-    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "MockAdapter":
-        """Create a copy with modified channels."""
-        new_adapter = MockAdapter(self.date_column)
-        new_adapter.channel_spend_columns = new_channel_columns
-        new_adapter._media_channels = new_channel_names
-        return new_adapter
-
 
 class TestPlaceboTest:
     """Test cases for PlaceboTest."""

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -105,6 +105,11 @@ class MockAdapter(BaseAdapter):
         }
         return channel_mapping.get(channel_name, {"spend": f"{channel_name.lower()}_spend"})
 
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+        """Get the name for a shuffled column based on the mock adapter's naming convention."""
+        # For mock adapter, use the same convention as Meridian (with suffix)
+        return f"{shuffled_channel_name}_{column_type}"
+
     def _create_adapter_with_placebo_channel(
         self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
     ) -> "MockAdapter":
@@ -256,6 +261,11 @@ class TestPlaceboTest:
                     "Radio": {"spend": "radio_spend", "impressions": "radio_impressions"},
                 }
                 return channel_mapping.get(channel_name, {"spend": f"{channel_name.lower()}_spend", "impressions": f"{channel_name.lower()}_impressions"})
+
+            def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+                """Get the name for a shuffled column based on the mock adapter's naming convention."""
+                # For this mock adapter, use the same convention as Meridian (with suffix)
+                return f"{shuffled_channel_name}_{column_type}"
 
             def _create_adapter_with_placebo_channel(
                 self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -78,19 +78,6 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-        """Add new channels to the adapter."""
-        if self.is_fitted:
-            raise RuntimeError("Cannot add channels to a fitted adapter")
-
-        # For mock adapter, assume channel names are the same as column names
-        added_columns = {}
-        for channel_name in new_channel_names:
-            self.channel_spend_columns.append(channel_name)
-            self._media_channels.append(channel_name)
-            added_columns[channel_name] = [channel_name]
-
-        return added_columns
 
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
@@ -235,22 +222,6 @@ class TestPlaceboTest:
                 new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
                 new_adapter._media_channels = self._media_channels.copy()
                 return new_adapter
-
-            def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-                if self.is_fitted:
-                    raise RuntimeError("Cannot add channels to a fitted adapter")
-
-                added_columns = {}
-                for channel_name in new_channel_names:
-                    self.channel_spend_columns.append(f"{channel_name.lower()}_spend")
-                    self._media_channels.append(channel_name)
-                    # For impressions regressors, add both spend and impressions columns
-                    added_columns[channel_name] = [
-                        f"{channel_name.lower()}_spend",
-                        f"{channel_name.lower()}_impressions",
-                    ]
-
-                return added_columns
 
             def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
                 return [f"{channel.lower()}_impressions" for channel in channel_names]

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -71,10 +71,6 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
-    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-        """Get the primary media regressor columns for specific channels."""
-        return channel_names
-
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel."""
         # For mock adapter, map channel names to their actual column names
@@ -209,9 +205,6 @@ class TestPlaceboTest:
 
             def get_channel_names(self) -> list[str]:
                 return self.media_channels
-
-            def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-                return [f"{channel.lower()}_impressions" for channel in channel_names]
 
             def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
                 """Get the original column names for a channel."""

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -30,12 +30,16 @@ class MockAdapter(BaseAdapter):
     def fit(self, data: pd.DataFrame) -> None:
         """Mock fit method."""
         self.is_fitted = True
-        # Set ROI results based on the data columns
-        if "tv_spend_shuffled" in data.columns:
-            # If shuffled channel is present, give it a low ROI
-            self._roi_results = pd.Series({"TV": 1.5, "Radio": 2.0, "TV_shuffled": 0.1})
-        else:
-            self._roi_results = pd.Series({"TV": 1.5, "Radio": 2.0})
+        # Set ROI results based on the data columns and current media channels
+        roi_dict = {}
+        for channel in self._media_channels:
+            if channel.endswith("_shuffled"):
+                # Give shuffled channels a low ROI
+                roi_dict[channel] = 0.1
+            else:
+                # Give original channels normal ROI
+                roi_dict[channel] = 1.5 if channel == "TV" else 2.0
+        self._roi_results = pd.Series(roi_dict)
 
     def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
         """Mock predict method."""
@@ -76,14 +80,23 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-    def add_channels(self, new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
         """Add new channels to the adapter."""
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
         
         # For mock adapter, assume channel names are the same as column names
-        self.channel_spend_columns.extend(new_channel_names)
-        self._media_channels.extend(new_channel_names)
+        added_columns = {}
+        for channel_name in new_channel_names:
+            self.channel_spend_columns.append(channel_name)
+            self._media_channels.append(channel_name)
+            added_columns[channel_name] = [channel_name]
+        
+        return added_columns
+
+    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
+        """Get the primary media regressor columns for specific channels."""
+        return channel_names
 
 
 class TestPlaceboTest:
@@ -146,3 +159,107 @@ class TestPlaceboTest:
         assert "shuffled_channel_roi" in df["general_metric_name"].values
         assert df["metric_value"].iloc[0] == 0.1
         assert df["metric_pass"].iloc[0] == True  # noqa: E712 
+
+    def test_placebo_test_with_impressions_regressors(self):
+        """Test that PlaceboTest correctly handles impressions regressors."""
+        # Create a mock adapter that simulates Meridian with impressions regressors
+        class MeridianStyleAdapter(BaseAdapter):
+            def __init__(self):
+                self.date_column = "date"
+                self.channel_spend_columns = ["tv_spend", "radio_spend"]
+                self._media_channels = ["TV", "Radio"]
+                self.is_fitted = False
+                self._roi_results = None
+
+            @property
+            def media_channels(self) -> list[str]:
+                return self._media_channels
+
+            @property
+            def primary_media_regressor_type(self) -> PrimaryMediaRegressor:
+                return PrimaryMediaRegressor.IMPRESSIONS
+
+            @property
+            def primary_media_regressor_columns(self) -> list[str]:
+                return ["tv_impressions", "radio_impressions"]
+
+            def fit(self, data: pd.DataFrame) -> None:
+                self.is_fitted = True
+                roi_dict = {}
+                for channel in self._media_channels:
+                    if channel.endswith("_shuffled"):
+                        roi_dict[channel] = 0.1
+                    else:
+                        roi_dict[channel] = 1.5 if channel == "TV" else 2.0
+                self._roi_results = pd.Series(roi_dict)
+
+            def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
+                return np.array([1.0, 2.0, 3.0])
+
+            def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray:
+                return np.array([1.0, 2.0])
+
+            def fit_and_predict_in_sample(self, data: pd.DataFrame) -> np.ndarray:
+                return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+            def get_channel_roi(self, start_date=None, end_date=None) -> pd.Series:
+                if not self.is_fitted:
+                    raise RuntimeError("Model must be fit before computing ROI")
+                return self._roi_results
+
+            def get_channel_names(self) -> list[str]:
+                return self.media_channels
+
+            def copy(self) -> "MeridianStyleAdapter":
+                new_adapter = MeridianStyleAdapter()
+                new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
+                new_adapter._media_channels = self._media_channels.copy()
+                return new_adapter
+
+            def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
+                if self.is_fitted:
+                    raise RuntimeError("Cannot add channels to a fitted adapter")
+                
+                added_columns = {}
+                for channel_name in new_channel_names:
+                    self.channel_spend_columns.append(f"{channel_name.lower()}_spend")
+                    self._media_channels.append(channel_name)
+                    # For impressions regressors, add both spend and impressions columns
+                    added_columns[channel_name] = [
+                        f"{channel_name.lower()}_spend",
+                        f"{channel_name.lower()}_impressions"
+                    ]
+                
+                return added_columns
+
+            def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
+                return [f"{channel.lower()}_impressions" for channel in channel_names]
+
+        # Create test data with both spend and impressions columns
+        dates = pd.date_range("2023-01-01", periods=10, freq="D")
+        data = pd.DataFrame({
+            "date": dates,
+            "response": np.random.randn(10) + 100,
+            "revenue": np.random.randn(10) + 1000,
+            "tv_spend": np.random.randn(10) + 50,
+            "radio_spend": np.random.randn(10) + 30,
+            "tv_impressions": np.random.randn(10) + 50000,
+            "radio_impressions": np.random.randn(10) + 25000,
+        })
+
+        # Create adapter and test
+        adapter = MeridianStyleAdapter()
+        test = PlaceboTest(date_column="date")
+        
+        # Run the test
+        result = test.run(adapter, data)
+        
+        # Verify the result
+        assert result.test_name == ValidationTestNames.PLACEBO
+        assert isinstance(result.test_scores, PlaceboMetricResults)
+        assert result.test_scores.shuffled_channel_roi == 0.1
+        assert result.test_scores.shuffled_channel_name.endswith("_shuffled")
+        
+        # The test should have worked correctly, indicating that the PlaceboTest
+        # can handle impressions regressors properly by shuffling the correct columns
+        # and using the adapter's column naming logic 

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -96,6 +96,20 @@ class MockAdapter(BaseAdapter):
         """Get the primary media regressor columns for specific channels."""
         return channel_names
 
+    def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
+        """Get the original column names for a channel."""
+        # For mock adapter, assume channel names are the same as column names
+        return {"spend": channel_name}
+
+    def _create_adapter_with_placebo_channel(
+        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+    ) -> "MockAdapter":
+        """Create a new adapter instance configured to use the placebo channel."""
+        new_adapter = MockAdapter(self.date_column)
+        new_adapter.channel_spend_columns = self.channel_spend_columns + [f"{shuffled_channel}_spend"]
+        new_adapter._media_channels = self._media_channels + [shuffled_channel]
+        return new_adapter
+
 
 class TestPlaceboTest:
     """Test cases for PlaceboTest."""
@@ -229,6 +243,24 @@ class TestPlaceboTest:
 
             def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
                 return [f"{channel.lower()}_impressions" for channel in channel_names]
+
+            def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
+                """Get the original column names for a channel."""
+                # For this mock adapter, map channel names to their spend and impressions columns
+                channel_mapping = {
+                    "TV": {"spend": "tv_spend", "impressions": "tv_impressions"},
+                    "Radio": {"spend": "radio_spend", "impressions": "radio_impressions"},
+                }
+                return channel_mapping.get(channel_name, {"spend": f"{channel_name.lower()}_spend", "impressions": f"{channel_name.lower()}_impressions"})
+
+            def _create_adapter_with_placebo_channel(
+                self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+            ) -> "MeridianStyleAdapter":
+                """Create a new adapter instance configured to use the placebo channel."""
+                new_adapter = MeridianStyleAdapter()
+                new_adapter.channel_spend_columns = self.channel_spend_columns + [f"{shuffled_channel.lower()}_spend"]
+                new_adapter._media_channels = self._media_channels + [shuffled_channel]
+                return new_adapter
 
         # Create test data with both spend and impressions columns
         dates = pd.date_range("2023-01-01", periods=10, freq="D")

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -98,8 +98,12 @@ class MockAdapter(BaseAdapter):
 
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel."""
-        # For mock adapter, assume channel names are the same as column names
-        return {"spend": channel_name}
+        # For mock adapter, map channel names to their actual column names
+        channel_mapping = {
+            "TV": {"spend": "tv_spend"},
+            "Radio": {"spend": "radio_spend"},
+        }
+        return channel_mapping.get(channel_name, {"spend": f"{channel_name.lower()}_spend"})
 
     def _create_adapter_with_placebo_channel(
         self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]

--- a/tests/test_validation_tests/test_placebo.py
+++ b/tests/test_validation_tests/test_placebo.py
@@ -69,6 +69,21 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
+    def copy(self) -> "MockAdapter":
+        """Create a deep copy of this adapter."""
+        new_adapter = MockAdapter(self.date_column)
+        new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
+        new_adapter._media_channels = self._media_channels.copy()
+        return new_adapter
+
+    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+        """Add new channels to the adapter."""
+        if self.is_fitted:
+            raise RuntimeError("Cannot add channels to a fitted adapter")
+        
+        self.channel_spend_columns.extend(new_channel_columns)
+        self._media_channels.extend(new_channel_names)
+
 
 class TestPlaceboTest:
     """Test cases for PlaceboTest."""

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -1,0 +1,142 @@
+"""Integration tests for PlaceboTest with validation orchestrator."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mmm_eval.adapters.base import BaseAdapter, PrimaryMediaRegressor
+from mmm_eval.core.validation_test_orchestrator import ValidationTestOrchestrator
+from mmm_eval.core.validation_tests_models import ValidationTestNames
+
+
+class MockAdapter(BaseAdapter):
+    """Mock adapter for testing PlaceboTest integration."""
+
+    def __init__(self, date_column: str = "date"):
+        """Initialize mock adapter."""
+        self.date_column = date_column
+        self.channel_spend_columns = ["tv_spend", "radio_spend"]
+        self._media_channels = ["TV", "Radio"]
+        self.is_fitted = False
+        self._roi_results = None
+
+    @property
+    def media_channels(self) -> list[str]:
+        """Return the channel names used by this adapter."""
+        return self._media_channels
+
+    def fit(self, data: pd.DataFrame) -> None:
+        """Mock fit method."""
+        self.is_fitted = True
+        # Set ROI results based on the data columns
+        if "tv_spend_shuffled" in data.columns:
+            # If shuffled channel is present, give it a low ROI
+            self._roi_results = pd.Series({"TV": 1.5, "Radio": 2.0, "TV_shuffled": 0.1})
+        else:
+            self._roi_results = pd.Series({"TV": 1.5, "Radio": 2.0})
+
+    def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
+        """Mock predict method."""
+        return np.array([1.0, 2.0, 3.0])
+
+    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray:
+        """Mock fit_and_predict method."""
+        return np.array([1.0, 2.0])
+
+    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> np.ndarray:
+        """Mock fit_and_predict_in_sample method."""
+        return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def get_channel_roi(self, start_date=None, end_date=None) -> pd.Series:
+        """Mock get_channel_roi method."""
+        if not self.is_fitted:
+            raise RuntimeError("Model must be fit before computing ROI")
+        return self._roi_results
+
+    def get_channel_names(self) -> list[str]:
+        """Mock get_channel_names method."""
+        return self.media_channels
+
+    @property
+    def primary_media_regressor_type(self) -> PrimaryMediaRegressor:
+        """Return the type of primary media regressors."""
+        return PrimaryMediaRegressor.SPEND
+
+    @property
+    def primary_media_regressor_columns(self) -> list[str]:
+        """Return the primary media regressor columns."""
+        return self.channel_spend_columns
+
+    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "MockAdapter":
+        """Create a copy with modified channels."""
+        new_adapter = MockAdapter(self.date_column)
+        new_adapter.channel_spend_columns = new_channel_columns
+        new_adapter._media_channels = new_channel_names
+        return new_adapter
+
+
+class TestPlaceboTestIntegration:
+    """Integration tests for PlaceboTest."""
+
+    def test_placebo_test_with_orchestrator(self):
+        """Test that PlaceboTest works with the validation orchestrator."""
+        # Create test data
+        dates = pd.date_range("2023-01-01", periods=10, freq="D")
+        data = pd.DataFrame({
+            "date": dates,
+            "response": np.random.randn(10) + 100,
+            "revenue": np.random.randn(10) + 1000,
+            "tv_spend": np.random.randn(10) + 50,
+            "radio_spend": np.random.randn(10) + 30,
+        })
+
+        # Create adapter and orchestrator
+        adapter = MockAdapter(date_column="date")
+        orchestrator = ValidationTestOrchestrator()
+        
+        # Run only the placebo test
+        results = orchestrator.validate(
+            adapter=adapter,
+            data=data,
+            test_names=[ValidationTestNames.PLACEBO],
+        )
+        
+        # Verify the results
+        assert ValidationTestNames.PLACEBO in results.test_results
+        placebo_result = results.get_test_result(ValidationTestNames.PLACEBO)
+        assert placebo_result.test_name == ValidationTestNames.PLACEBO
+        assert placebo_result.test_scores.shuffled_channel_roi == 0.1
+        assert placebo_result.test_scores.shuffled_channel_name.endswith("_shuffled")
+
+    def test_placebo_test_in_dataframe_output(self):
+        """Test that PlaceboTest results are properly included in DataFrame output."""
+        # Create test data
+        dates = pd.date_range("2023-01-01", periods=10, freq="D")
+        data = pd.DataFrame({
+            "date": dates,
+            "response": np.random.randn(10) + 100,
+            "revenue": np.random.randn(10) + 1000,
+            "tv_spend": np.random.randn(10) + 50,
+            "radio_spend": np.random.randn(10) + 30,
+        })
+
+        # Create adapter and orchestrator
+        adapter = MockAdapter(date_column="date")
+        orchestrator = ValidationTestOrchestrator()
+        
+        # Run only the placebo test
+        results = orchestrator.validate(
+            adapter=adapter,
+            data=data,
+            test_names=[ValidationTestNames.PLACEBO],
+        )
+        
+        # Convert to DataFrame
+        df = results.to_df()
+        
+        # Verify the DataFrame contains placebo test results
+        placebo_rows = df[df["test_name"] == ValidationTestNames.PLACEBO.value]
+        assert len(placebo_rows) == 1
+        assert placebo_rows["general_metric_name"].iloc[0] == "shuffled_channel_roi"
+        assert placebo_rows["metric_value"].iloc[0] == 0.1
+        assert placebo_rows["metric_pass"].iloc[0] == True  # noqa: E712 

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -67,6 +67,21 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
+    def copy(self) -> "MockAdapter":
+        """Create a deep copy of this adapter."""
+        new_adapter = MockAdapter(self.date_column)
+        new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
+        new_adapter._media_channels = self._media_channels.copy()
+        return new_adapter
+
+    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+        """Add new channels to the adapter."""
+        if self.is_fitted:
+            raise RuntimeError("Cannot add channels to a fitted adapter")
+        
+        self.channel_spend_columns.extend(new_channel_columns)
+        self._media_channels.extend(new_channel_names)
+
 
 class TestPlaceboTestIntegration:
     """Integration tests for PlaceboTest."""

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -70,13 +70,6 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
-    def copy(self) -> "MockAdapter":
-        """Create a deep copy of this adapter."""
-        new_adapter = MockAdapter(self.date_column)
-        new_adapter.channel_spend_columns = self.channel_spend_columns.copy()
-        new_adapter._media_channels = self._media_channels.copy()
-        return new_adapter
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
         return channel_names

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -31,8 +31,8 @@ class MockAdapter(BaseAdapter):
         roi_dict = {}
         for channel in self._media_channels:
             if channel.endswith("_shuffled"):
-                # Give shuffled channels a low ROI
-                roi_dict[channel] = 0.1
+                # Give shuffled channels a low ROI (should pass threshold of -50%)
+                roi_dict[channel] = -60.0
             else:
                 # Give original channels normal ROI
                 roi_dict[channel] = 1.5 if channel == "TV" else 2.0
@@ -147,7 +147,7 @@ class TestPlaceboTestIntegration:
         assert ValidationTestNames.PLACEBO in results.test_results
         placebo_result = results.get_test_result(ValidationTestNames.PLACEBO)
         assert placebo_result.test_name == ValidationTestNames.PLACEBO
-        assert placebo_result.test_scores.shuffled_channel_roi == 0.1
+        assert placebo_result.test_scores.shuffled_channel_roi == -60.0
         assert placebo_result.test_scores.shuffled_channel_name.endswith("_shuffled")
 
     def test_placebo_test_in_dataframe_output(self):
@@ -182,5 +182,5 @@ class TestPlaceboTestIntegration:
         placebo_rows = df[df["test_name"] == ValidationTestNames.PLACEBO.value]
         assert len(placebo_rows) == 1
         assert placebo_rows["general_metric_name"].iloc[0] == "shuffled_channel_roi"
-        assert placebo_rows["metric_value"].iloc[0] == 0.1
+        assert placebo_rows["metric_value"].iloc[0] == -60.0
         assert placebo_rows["metric_pass"].iloc[0] == True  # noqa: E712

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -67,13 +67,6 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
-    def copy_with_modified_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> "MockAdapter":
-        """Create a copy with modified channels."""
-        new_adapter = MockAdapter(self.date_column)
-        new_adapter.channel_spend_columns = new_channel_columns
-        new_adapter._media_channels = new_channel_names
-        return new_adapter
-
 
 class TestPlaceboTestIntegration:
     """Integration tests for PlaceboTest."""

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -95,6 +95,20 @@ class MockAdapter(BaseAdapter):
         """Get the primary media regressor columns for specific channels."""
         return channel_names
 
+    def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
+        """Get the original column names for a channel."""
+        # For mock adapter, assume channel names are the same as column names
+        return {"spend": channel_name}
+
+    def _create_adapter_with_placebo_channel(
+        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+    ) -> "MockAdapter":
+        """Create a new adapter instance configured to use the placebo channel."""
+        new_adapter = MockAdapter(self.date_column)
+        new_adapter.channel_spend_columns = self.channel_spend_columns + [f"{shuffled_channel}_spend"]
+        new_adapter._media_channels = self._media_channels + [shuffled_channel]
+        return new_adapter
+
 
 class TestPlaceboTestIntegration:
     """Integration tests for PlaceboTest."""

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -70,10 +70,6 @@ class MockAdapter(BaseAdapter):
         """Return the primary media regressor columns."""
         return self.channel_spend_columns
 
-    def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
-        """Get the primary media regressor columns for specific channels."""
-        return channel_names
-
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel."""
         # For mock adapter, map channel names to their actual column names

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -77,19 +77,6 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-    def add_channels(self, new_channel_names: list[str]) -> dict[str, list[str]]:
-        """Add new channels to the adapter."""
-        if self.is_fitted:
-            raise RuntimeError("Cannot add channels to a fitted adapter")
-
-        # For mock adapter, assume channel names are the same as column names
-        added_columns = {}
-        for channel_name in new_channel_names:
-            self.channel_spend_columns.append(channel_name)
-            self._media_channels.append(channel_name)
-            added_columns[channel_name] = [channel_name]
-
-        return added_columns
 
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -100,6 +100,11 @@ class MockAdapter(BaseAdapter):
         # For mock adapter, assume channel names are the same as column names
         return {"spend": channel_name}
 
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+        """Get the name for a shuffled column based on the mock adapter's naming convention."""
+        # For mock adapter, use the same convention as Meridian (with suffix)
+        return f"{shuffled_channel_name}_{column_type}"
+
     def _create_adapter_with_placebo_channel(
         self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
     ) -> "MockAdapter":

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -74,12 +74,13 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-    def add_channels(self, new_channel_columns: list[str], new_channel_names: list[str]) -> None:
+    def add_channels(self, new_channel_names: list[str]) -> None:
         """Add new channels to the adapter."""
         if self.is_fitted:
             raise RuntimeError("Cannot add channels to a fitted adapter")
         
-        self.channel_spend_columns.extend(new_channel_columns)
+        # For mock adapter, assume channel names are the same as column names
+        self.channel_spend_columns.extend(new_channel_names)
         self._media_channels.extend(new_channel_names)
 
 

--- a/tests/test_validation_tests/test_placebo_integration.py
+++ b/tests/test_validation_tests/test_placebo_integration.py
@@ -77,23 +77,28 @@ class MockAdapter(BaseAdapter):
         new_adapter._media_channels = self._media_channels.copy()
         return new_adapter
 
-
     def get_primary_media_regressor_columns_for_channels(self, channel_names: list[str]) -> list[str]:
         """Get the primary media regressor columns for specific channels."""
         return channel_names
 
     def _get_original_channel_columns(self, channel_name: str) -> dict[str, str]:
         """Get the original column names for a channel."""
-        # For mock adapter, assume channel names are the same as column names
-        return {"spend": channel_name}
+        # For mock adapter, map channel names to their actual column names
+        # The data has columns like "tv_spend", "radio_spend"
+        channel_mapping = {
+            "TV": {"spend": "tv_spend"},
+            "Radio": {"spend": "radio_spend"},
+        }
+        return channel_mapping.get(channel_name, {"spend": f"{channel_name.lower()}_spend"})
 
-    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str, original_col: str) -> str:
+    def _get_shuffled_col_name(self, shuffled_channel_name: str, column_type: str) -> str:
         """Get the name for a shuffled column based on the mock adapter's naming convention."""
         # For mock adapter, use the same convention as Meridian (with suffix)
         return f"{shuffled_channel_name}_{column_type}"
 
     def _create_adapter_with_placebo_channel(
-        self, original_channel: str, shuffled_channel: str, original_columns: dict[str, str]
+        self,
+        shuffled_channel: str,
     ) -> "MockAdapter":
         """Create a new adapter instance configured to use the placebo channel."""
         new_adapter = MockAdapter(self.date_column)


### PR DESCRIPTION
Add placebo test, which adds a spurious media channel which has no relation to sales into the model and calculates the average ROI for that channel. In a performant and well-specified model, it should be correctly identified as spurious and have a low ROI associated with it.

The spurious channel is constructed by randomly permuting the order of an actual media channel to preserve the marginal distribution but destroy the temporal structure.