### PR TITLE
feat: Add Scaled CRPS as an accuracy metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] ; 2025-11-07
+
+- Add Scaled CRPS as an accuracy metric.
+
 ## [0.12.0] ; 2025-07-23
 
 ### Added

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -16,6 +16,7 @@ mmm-eval calculates several key metrics across different validation tests:
 - **MAPE (Mean Absolute Percentage Error)**: Average percentage error between predictions and actual values
 - **SMAPE (Symmetric Mean Absolute Percentage Error)**: Symmetric version of MAPE that treats over and underestimation equally
 - **R-squared**: Proportion of variance explained by the model
+- **CRPS (Continuous Ranked Probability Score)**: Distributional accuracy metric
 
 ### Stability Metrics
 
@@ -62,6 +63,19 @@ R² = 1 - (Σ(y_i - ŷ_i)² / Σ(y_i - ȳ)²)
 - **Range**: 0 to 1 (higher is better)
 - **Scale**: 1 = perfect fit, 0 = no predictive power
 - **Benchmark**: > 0.8 is generally good
+
+### CRPS (Continuous Ranked Probability Score)
+
+```python
+CRPS = ((1/n) * Σ|y_i - ŷ| - (0.5/n) * Σ|y_i - x_i|) / y_i)
+```
+where `x_i` and `y_i` are samples from the posterior predictive distribution
+
+
+**Interpretation**:
+- **Lower is better**: 0% = perfect predictions, no uncertainty
+- **Scale**: Expressed as a percentage, e.g. 15.0 rather than 0.15
+
 
 ## Test-Specific Metrics
 

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -86,6 +86,7 @@ Metrics calculated on out-of-sample predictions using train/test splits.
 - **MAPE**: Overall prediction accuracy
 - **SMAPE**: Symmetric prediction accuracy
 - **R-squared**: Model fit quality
+- **CRPS**: Distribution prediction accuracy
 
 ### In-Sample Accuracy Test Metrics
 
@@ -94,6 +95,8 @@ Metrics calculated on in-sample predictions using the full dataset.
 - **MAPE**: Model fit accuracy
 - **SMAPE**: Symmetric model fit accuracy
 - **R-squared**: Model fit quality
+- **CRPS**: Distribution prediction accuracy
+
 
 ### Cross-Validation Metrics
 
@@ -103,6 +106,8 @@ Metrics calculated on in-sample predictions using the full dataset.
 - **Std SMAPE**: Consistency of symmetric accuracy across folds
 - **Mean R-squared**: Average out-of-sample fit
 - **Std R-squared**: Consistency of fit across folds
+- **Mean CRPS**: Average distribution prediction accuracy
+
 
 ### Refresh Stability Metrics
 
@@ -132,6 +137,7 @@ model picking up spurious correlations.
 - **MAPE < 15%**: Good prediction accuracy
 - **SMAPE < 15%**: Good symmetric prediction accuracy
 - **R-squared > 0.8**: Strong model fit
+- **CRPS < 15%**: Good distributional accuracy
 - **Low perturbation sensitivity**: Robust to input noise
 - **Low placebo ROI (≤ -50%)**: Correctly identifies spurious features and assigns them low effect sizes
 
@@ -148,6 +154,7 @@ model specification to the problem at hand.
 | MAPE | < 5% | 5-10% | 10-15% | > 15% |
 | SMAPE | < 5% | 5-10% | 10-15% | > 15% |
 | R-squared | > 0.9 | 0.8-0.9 | 0.6-0.8 | < 0.6 |
+| CRPS | < 5% | 5-10% | 10-15% | > 15% |
 | Parameter Change | < 5% | 5-10% | 10-20% | > 20% |
 | Perturbation Change | < 5% | 5-10% | 10-15% | > 15% |
 | Placebo ROI | ≤ -50% | -50% to -25% | -25% to 0% | > 0% |
@@ -179,6 +186,7 @@ class CustomMetric(BaseMetric):
 - **Start with MAPE**: Most intuitive for business users
 - **Include SMAPE**: More robust alternative to MAPE for symmetric evaluation
 - **Include R-squared**: Technical measure of fit quality
+- **Add CRPS**: Measure the uncertainty of the predictions
 - **Monitor stability**: Critical for production models
 - **Track performance**: Important for scalability
 

--- a/docs/user-guide/tests.md
+++ b/docs/user-guide/tests.md
@@ -39,12 +39,14 @@ The holdout accuracy test evaluates model performance by splitting data into tra
 - **MAPE (Mean Absolute Percentage Error)**: Average percentage error
 - **SMAPE (Symmetric Mean Absolute Percentage Error)**: Symmetric version of MAPE
 - **R-squared**: Proportion of variance explained by the model
+- **CRPS (Continuous Ranked Probability Score)**: Distribution accuracy metric, scaled to sales levels.
 
 #### Interpretation
 
 - **Lower MAPE**: Better model performance
 - **Lower SMAPE**: Better symmetric model performance
 - **Higher R-squared**: Better model fit (0-1 scale)
+- **Lower CRPS**: Less uncertainty
 
 ### In-Sample Accuracy Test
 
@@ -61,12 +63,14 @@ The in-sample accuracy test evaluates model performance by fitting the model on 
 - **MAPE (Mean Absolute Percentage Error)**: Average percentage error
 - **SMAPE (Symmetric Mean Absolute Percentage Error)**: Symmetric version of MAPE
 - **R-squared**: Proportion of variance explained by the model
+- **CRPS (Continuous Ranked Probability Score)**: Distribution accuracy metric, scaled to sales levels.
 
 #### Interpretation
 
 - **Lower MAPE**: Better model fit to training data
 - **Lower SMAPE**: Better symmetric model fit
 - **Higher R-squared**: Better explanatory power
+- **Lower CRPS**: Less uncertainty
 - **Comparison with holdout**: Helps identify overfitting (much better in-sample than holdout performance)
 
 ## Cross-Validated Holdout Accuracy Test
@@ -94,6 +98,8 @@ integers)
 - **MAPE**: Out-of-sample prediction accuracy
 - **SMAPE**: Out-of-sample symmetric prediction accuracy
 - **R-squared**: Out-of-sample explanatory power
+- **CRPS**: Out-of-sample predictive distribution accuracy
+
 
 ### Interpretation
 
@@ -215,8 +221,8 @@ modify the thresholds in `mmm_eval/metrics/threshold_constants.py`.
 
 ### Good Model Indicators
 
-- **Holdout Accuracy**: MAPE < 15%, SMAPE < 15%, R-squared > 0.8
-- **In-Sample Accuracy**: MAPE < 10%, SMAPE < 10%, R-squared > 0.9
+- **Holdout Accuracy**: MAPE < 15%, SMAPE < 15%, R-squared > 0.8, CRPS < 15%
+- **In-Sample Accuracy**: MAPE < 10%, SMAPE < 10%, R-squared > 0.9, CRPS < 10%
 - **Cross-Validation**: Out-of-sample MAPE/SMAPE similar to in-sample
 - **Refresh Stability**: Parameter changes < 10%
 - **Perturbation**: ROI changes < 5%
@@ -225,6 +231,7 @@ modify the thresholds in `mmm_eval/metrics/threshold_constants.py`.
 ### Warning Signs
 
 - **Poor Performance**: High MAPE/SMAPE or low R-squared
+- **High Uncertainty**: CRPS significantly higher than MAPE
 - **Overfitting**: Much better in-sample than holdout performance
 - **Unstable Model**: Large parameter changes
 - **Data Issues**: Missing values or extreme outliers

--- a/mmm_eval/adapters/base.py
+++ b/mmm_eval/adapters/base.py
@@ -86,7 +86,7 @@ class BaseAdapter(ABC):
         pass
 
     @abstractmethod
-    def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
+    def predict(self, data: pd.DataFrame | None = None) -> tuple[np.ndarray, np.ndarray]:
         """Make predictions on new data.
 
         Args:
@@ -97,13 +97,13 @@ class BaseAdapter(ABC):
                   the fitted model state instead
 
         Returns:
-            Predicted values
+            Predicted values, tuple of (posterior_mean, posterior_distribution)
 
         """
         pass
 
     @abstractmethod
-    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray:
+    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
         """Fit on training data and make predictions on test data.
 
         Args:
@@ -111,20 +111,20 @@ class BaseAdapter(ABC):
             test: dataset to make predictions using
 
         Returns:
-            Predicted values.
+            Predicted values, tuple of (posterior_mean, posterior_distribution)
 
         """
         pass
 
     @abstractmethod
-    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> np.ndarray:
+    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
         """Fit the model on data and return predictions for the same data.
 
         Args:
             data: dataset to train model on and make predictions for
 
         Returns:
-            Predicted values for the training data.
+            Predicted values for the training data, tuple of (posterior_mean, posterior_distribution)
 
         """
         pass

--- a/mmm_eval/adapters/meridian.py
+++ b/mmm_eval/adapters/meridian.py
@@ -519,11 +519,11 @@ class MeridianAdapter(BaseAdapter):
         self.analyzer = Analyzer(self.model)
         self.is_fitted = True
 
-    def _predict_on_all_data(self) -> np.ndarray:
+    def _predict_on_all_data(self) -> tuple[np.ndarray, np.ndarray]:
         """Make predictions on all data provided to fit().
 
         Returns
-            predicted values on data provided to fit().
+            predicted values on data provided to fit(), tuple of (posterior_mean, posterior_distribution)
 
         """
         if not self.is_fitted or self.analyzer is None:
@@ -532,9 +532,11 @@ class MeridianAdapter(BaseAdapter):
         # shape (n_chains, n_draws, n_times)
         preds_tensor = self.analyzer.expected_outcome(aggregate_geos=True, aggregate_times=False, use_kpi=True)
         posterior_mean = np.mean(preds_tensor, axis=(0, 1))
-        return posterior_mean
+        # A (n sample x n_chain) by n_time matrix
+        posterior_distribution = np.array(preds_tensor).reshape(-1, preds_tensor.shape[-1])
+        return posterior_mean, posterior_distribution
 
-    def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
+    def predict(self, data: pd.DataFrame | None = None) -> tuple[np.ndarray, np.ndarray]:
         """Make predictions using the fitted model.
 
         This returns predictions for the entirety of the dataset passed to fit() unless
@@ -548,22 +550,22 @@ class MeridianAdapter(BaseAdapter):
             data: Ignored - Meridian uses the fitted model state for predictions.
 
         Returns:
-            Predicted values
+            Predicted values, tuple of (posterior_mean, posterior_distribution)
 
         Raises:
             RuntimeError: If model is not fitted
 
         """
-        posterior_mean = self._predict_on_all_data()
+        posterior_mean, posterior_distribution = self._predict_on_all_data()
 
         # if holdout mask is provided, use it to mask the predictions to restrict only to the
         # holdout period
         if self.holdout_mask is not None:
             posterior_mean = posterior_mean[self.holdout_mask]
+            posterior_distribution = posterior_distribution[:, self.holdout_mask]
+        return posterior_mean, posterior_distribution
 
-        return posterior_mean
-
-    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray:
+    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
         """Fit the Meridian model and make predictions given new input data.
 
         The full dataset must be passed to `fit()`, since making out-of-sample predictions
@@ -575,7 +577,7 @@ class MeridianAdapter(BaseAdapter):
             test: Test data
 
         Returns:
-            Predicted values for the test period
+            Predicted values for the test period, tuple of (posterior_mean, posterior_distribution)
 
         """
         train_and_test = pd.concat([train, test])
@@ -583,19 +585,20 @@ class MeridianAdapter(BaseAdapter):
         self.fit(train_and_test, max_train_date=max_train_date)
         return self.predict()
 
-    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> np.ndarray:
+    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
         """Fit the model on data and return predictions for the same data.
 
         Args:
             data: dataset to train model on and make predictions for
 
         Returns:
-            Predicted values for the training data.
+            Predicted values for the training data, tuple of (posterior_mean, posterior_distribution)
 
         """
         # no max train date specified, so predictions are all in-sample
         self.fit(data)
-        return self._predict_on_all_data()
+        posterior_mean, posterior_distribution = self._predict_on_all_data()
+        return posterior_mean, posterior_distribution
 
     def get_channel_roi(
         self,

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -198,7 +198,7 @@ class PyMCAdapter(BaseAdapter):
         self._channel_roi_df = self._compute_channel_contributions(data)
         self.is_fitted = True
 
-    def predict(self, data: pd.DataFrame | None = None) -> np.ndarray:
+    def predict(self, data: pd.DataFrame | None = None) -> tuple[np.ndarray, np.ndarray]:
         """Predict the response variable for new data.
 
         Args:
@@ -206,7 +206,7 @@ class PyMCAdapter(BaseAdapter):
                 predictions and cannot be None.
 
         Returns:
-            Predicted values
+            Predicted values, tuple of (posterior_mean, posterior_distribution)
 
         Raises:
             RuntimeError: If model is not fitted
@@ -221,12 +221,14 @@ class PyMCAdapter(BaseAdapter):
 
         if InputDataframeConstants.RESPONSE_COL in data.columns:
             data = data.drop(columns=[InputDataframeConstants.RESPONSE_COL])
-        predictions = predictions = self.model.predict(
-            data, extend_idata=False, include_last_observations=True, **self.predict_kwargs
-        )
-        return predictions
 
-    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray:
+        posterior_prediction = self.model.predict_posterior(
+            data, extend_idata=False, include_last_observations=True, combined=True, **self.predict_kwargs
+        )
+        posterior_mean = posterior_prediction.mean(axis=1)
+        return posterior_mean, posterior_prediction.transpose()
+
+    def fit_and_predict(self, train: pd.DataFrame, test: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
         """Fit on training data and make predictions on test data.
 
         Arguments:
@@ -234,26 +236,26 @@ class PyMCAdapter(BaseAdapter):
             test: test dataset
 
         Returns:
-            model predictions.
+            model predictions, tuple of (posterior_mean, posterior_distribution)
 
         """
         self.fit(train)
         return self.predict(test)
 
-    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> np.ndarray:
+    def fit_and_predict_in_sample(self, data: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
         """Fit the model on data and return predictions for the same data.
 
         Args:
             data: dataset to train model on and make predictions for
 
         Returns:
-            Predicted values for the training data.
+            Predicted values for the training data, tuple of (posterior_mean, posterior_distribution)
 
         """
         self.fit(data)
         if self.model is None:
             raise RuntimeError("Model must be fit before prediction.")
-        return self.model.predict(data, extend_idata=False, **self.predict_kwargs)
+        return self.predict(data)
 
     def get_channel_roi(
         self,

--- a/mmm_eval/adapters/pymc.py
+++ b/mmm_eval/adapters/pymc.py
@@ -225,6 +225,7 @@ class PyMCAdapter(BaseAdapter):
         posterior_prediction = self.model.predict_posterior(
             data, extend_idata=False, include_last_observations=True, combined=True, **self.predict_kwargs
         )
+        posterior_prediction = np.array(posterior_prediction)
         posterior_mean = posterior_prediction.mean(axis=1)
         return posterior_mean, posterior_prediction.transpose()
 

--- a/mmm_eval/core/constants.py
+++ b/mmm_eval/core/constants.py
@@ -6,7 +6,7 @@ class ValidationTestConstants:
 
     ACCURACY_TEST_SIZE = 8
     RANDOM_STATE = 42
-    N_SPLITS = 5
+    N_SPLITS = 2
     TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4
 
     class PerturbationConstants:

--- a/mmm_eval/core/constants.py
+++ b/mmm_eval/core/constants.py
@@ -6,7 +6,7 @@ class ValidationTestConstants:
 
     ACCURACY_TEST_SIZE = 8
     RANDOM_STATE = 42
-    N_SPLITS = 2
+    N_SPLITS = 5
     TIME_SERIES_CROSS_VALIDATION_TEST_SIZE = 4
 
     class PerturbationConstants:

--- a/mmm_eval/core/validation_tests.py
+++ b/mmm_eval/core/validation_tests.py
@@ -30,6 +30,7 @@ from mmm_eval.metrics.metric_models import (
     RefreshStabilityMetricNames,
     RefreshStabilityMetricResults,
 )
+from mmm_eval.utils.validation_utils import distribution_to_dataframe
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class HoldoutAccuracyTest(BaseValidationTest):
         """Run the accuracy test."""
         # Split data into train/test sets
         train, test = self._split_data_holdout(data)
-        predictions = adapter.fit_and_predict(train, test)
+        predictions, distribution = adapter.fit_and_predict(train, test)
         actual = test.groupby(self.date_column)[InputDataframeConstants.RESPONSE_COL].sum()
         assert len(actual) == len(predictions), "Actual and predicted lengths must match"
 
@@ -58,6 +59,8 @@ class HoldoutAccuracyTest(BaseValidationTest):
         test_scores = AccuracyMetricResults.populate_object_with_metrics(
             actual=pd.Series(actual),  # Ensure it's a Series
             predicted=pd.Series(predictions, index=actual.index),
+            distribution=distribution_to_dataframe(distribution, index=actual.index),
+            date_column=self.date_column,
         )
 
         logger.info(f"Saving the test results for {self.test_name} test")
@@ -84,7 +87,7 @@ class InSampleAccuracyTest(BaseValidationTest):
     def run(self, adapter: BaseAdapter, data: pd.DataFrame) -> ValidationTestResult:
         """Run the in-sample accuracy test."""
         # Fit model on full dataset and get predictions
-        predictions = adapter.fit_and_predict_in_sample(data)
+        predictions, distribution = adapter.fit_and_predict_in_sample(data)
         actual = data.groupby(self.date_column)[InputDataframeConstants.RESPONSE_COL].sum()
         assert len(actual) == len(predictions), "Actual and predicted lengths must match"
 
@@ -92,6 +95,8 @@ class InSampleAccuracyTest(BaseValidationTest):
         test_scores = AccuracyMetricResults.populate_object_with_metrics(
             actual=pd.Series(actual),  # Ensure it's a Series
             predicted=pd.Series(predictions, index=actual.index),
+            distribution=distribution_to_dataframe(distribution, index=actual.index),
+            date_column=self.date_column,
         )
 
         logger.info(f"Saving the test results for {self.test_name} test")
@@ -139,7 +144,7 @@ class CrossValidationTest(BaseValidationTest):
             test = data.loc[test_idx]
 
             # Get predictions
-            predictions = adapter.fit_and_predict(train, test)
+            predictions, distribution = adapter.fit_and_predict(train, test)
             actual = test.groupby(self.date_column)[InputDataframeConstants.RESPONSE_COL].sum()
             assert len(actual) == len(predictions), "Actual and predicted lengths must match"
 
@@ -148,6 +153,8 @@ class CrossValidationTest(BaseValidationTest):
                 AccuracyMetricResults.populate_object_with_metrics(
                     actual=pd.Series(actual),  # Ensure it's a Series
                     predicted=pd.Series(predictions, index=actual.index),
+                    distribution=distribution_to_dataframe(distribution, index=actual.index),
+                    date_column=self.date_column,
                 )
             )
 
@@ -167,6 +174,9 @@ class CrossValidationTest(BaseValidationTest):
             ),
             mean_r_squared=calculate_mean_for_singular_values_across_cross_validation_folds(
                 fold_metrics, AccuracyMetricNames.R_SQUARED
+            ),
+            mean_crps=calculate_mean_for_singular_values_across_cross_validation_folds(
+                fold_metrics, AccuracyMetricNames.CRPS
             ),
         )
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -299,7 +299,7 @@ class AccuracyMetricResults(MetricResults):
             mape=mean_absolute_percentage_error(actual, predicted) * 100,
             smape=calculate_smape(actual, predicted),
             r_squared=r2_score(actual, predicted),
-            crps=calculate_crps(actual, predicted, date_column),
+            crps=calculate_crps(actual, distribution, date_column),
         )
 
 

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -52,6 +52,56 @@ def calculate_smape(actual: pd.Series, predicted: pd.Series) -> float:
     return float(smape)
 
 
+def crps_one_date(df: pd.DataFrame) -> float:
+    """Calculate CRPS for a single date.
+
+    CRPS is a probabilistic generalisation of the mean absolute error,
+    i.e, if the distribution is a repeat of a single value, CRPS is equal to the mean absolute error
+    We scale it by 100 / response to make it in the same units as MAPE for ease of comparison and thresholding.
+
+    Args:
+        df: DataFrame containing the response and predicted distribution
+
+    Returns:
+        Scaled CRPS value as float
+
+    """
+    response = df["response"].values[0]
+    n_samples = df.shape[0]
+    if n_samples == 1:
+        # CRPS reduces to absolute error for one sample
+        crps = np.abs(df["pred_distribution"].values[0] - response)
+    else:
+        pred_sample_one = df.iloc[: n_samples // 2]["pred_distribution"].values
+        pred_sample_two = df.iloc[n_samples // 2 :]["pred_distribution"].values
+        if len(pred_sample_two) != len(pred_sample_one):
+            # If an odd number of samples, drop the last one
+            pred_sample_two = pred_sample_two[:-1]
+
+        crps = np.mean(np.abs(pred_sample_one - response)) - 0.5 * np.mean(np.abs(pred_sample_one - pred_sample_two))
+
+    response_bounded = max(response, 1e-5)
+    return 100 * crps / response_bounded
+
+
+def calculate_crps(response_series: pd.Series, predicted_distribution: pd.DataFrame, date_column: str) -> float:
+    """Calculate Mean Continuous Ranked Probability Score (CRPS).
+
+    Args:
+        response_series: A series of the actual sales values
+        predicted_distribution: A dataframe containing a sample of the prediction distribution for each date.
+            If there is only a single sample, the CRPS reduces to the mean absolute (percentage) error.
+
+    Returns:
+        Scaled CRPS value as float
+
+    """
+    response_series.name = "response"
+    predicted_distribution = predicted_distribution.merge(response_series.reset_index(), on=date_column)
+
+    return predicted_distribution.groupby(date_column).apply(crps_one_date).mean()
+
+
 class MetricNamesBase(Enum):
     """Base class for metric name enums."""
 
@@ -67,6 +117,7 @@ class AccuracyMetricNames(MetricNamesBase):
     MAPE = "mape"
     SMAPE = "smape"
     R_SQUARED = "r_squared"
+    CRPS = "crps"
 
 
 class CrossValidationMetricNames(MetricNamesBase):
@@ -77,6 +128,7 @@ class CrossValidationMetricNames(MetricNamesBase):
     MEAN_SMAPE = "mean_smape"
     STD_SMAPE = "std_smape"
     MEAN_R_SQUARED = "mean_r_squared"
+    MEAN_CRPS = "mean_crps"
 
 
 class RefreshStabilityMetricNames(MetricNamesBase):
@@ -181,6 +233,7 @@ class AccuracyMetricResults(MetricResults):
     mape: float
     smape: float
     r_squared: float
+    crps: float
 
     def _check_metric_threshold(self, metric_name: str, metric_value: float) -> bool:
         """Check if a specific accuracy metric passes its threshold."""
@@ -190,6 +243,8 @@ class AccuracyMetricResults(MetricResults):
             return bool(metric_value <= AccuracyThresholdConstants.SMAPE)
         elif metric_name == AccuracyMetricNames.R_SQUARED.value:
             return bool(metric_value >= AccuracyThresholdConstants.R_SQUARED)
+        elif metric_name == AccuracyMetricNames.CRPS.value:
+            return bool(metric_value <= AccuracyThresholdConstants.CRPS)
         else:
             valid_metric_names = AccuracyMetricNames.to_list()
             raise InvalidMetricNameException(
@@ -215,17 +270,26 @@ class AccuracyMetricResults(MetricResults):
                     specific_metric_name=AccuracyMetricNames.R_SQUARED.value,
                     metric_value=self.r_squared,
                 ),
+                self._create_single_metric_dataframe_row(
+                    general_metric_name=AccuracyMetricNames.CRPS.value,
+                    specific_metric_name=AccuracyMetricNames.CRPS.value,
+                    metric_value=self.crps,
+                ),
             ]
         )
         return self.add_pass_fail_column(df)
 
     @classmethod
-    def populate_object_with_metrics(cls, actual: pd.Series, predicted: pd.Series) -> "AccuracyMetricResults":
+    def populate_object_with_metrics(
+        cls, actual: pd.Series, predicted: pd.Series, distribution: pd.DataFrame, date_column: str
+    ) -> "AccuracyMetricResults":
         """Populate the object with the calculated metrics.
 
         Args:
             actual: The actual values
             predicted: The predicted values
+            distribution: The predicted distribution
+            date_column: The name of the date column
 
         Returns:
             AccuracyMetricResults object with the metrics
@@ -235,6 +299,7 @@ class AccuracyMetricResults(MetricResults):
             mape=mean_absolute_percentage_error(actual, predicted) * 100,
             smape=calculate_smape(actual, predicted),
             r_squared=r2_score(actual, predicted),
+            crps=calculate_crps(actual, predicted, date_column),
         )
 
 
@@ -246,6 +311,7 @@ class CrossValidationMetricResults(MetricResults):
     mean_smape: float
     std_smape: float
     mean_r_squared: float
+    mean_crps: float
 
     def _check_metric_threshold(self, metric_name: str, metric_value: float) -> bool:
         """Check if a specific cross-validation metric passes its threshold."""
@@ -259,6 +325,8 @@ class CrossValidationMetricResults(MetricResults):
             return bool(metric_value <= CrossValidationThresholdConstants.STD_SMAPE)
         elif metric_name == CrossValidationMetricNames.MEAN_R_SQUARED.value:
             return bool(metric_value >= CrossValidationThresholdConstants.MEAN_R_SQUARED)
+        elif metric_name == CrossValidationMetricNames.MEAN_CRPS.value:
+            return bool(metric_value <= CrossValidationThresholdConstants.MEAN_CRPS)
         else:
             valid_metric_names = CrossValidationMetricNames.to_list()
             raise InvalidMetricNameException(
@@ -293,6 +361,11 @@ class CrossValidationMetricResults(MetricResults):
                     general_metric_name=CrossValidationMetricNames.MEAN_R_SQUARED.value,
                     specific_metric_name=CrossValidationMetricNames.MEAN_R_SQUARED.value,
                     metric_value=self.mean_r_squared,
+                ),
+                self._create_single_metric_dataframe_row(
+                    general_metric_name=CrossValidationMetricNames.MEAN_CRPS.value,
+                    specific_metric_name=CrossValidationMetricNames.MEAN_CRPS.value,
+                    metric_value=self.mean_crps,
                 ),
             ]
         )

--- a/mmm_eval/metrics/metric_models.py
+++ b/mmm_eval/metrics/metric_models.py
@@ -72,13 +72,14 @@ def crps_one_date(df: pd.DataFrame) -> float:
         # CRPS reduces to absolute error for one sample
         crps = np.abs(df["pred_distribution"].values[0] - response)
     else:
-        pred_sample_one = df.iloc[: n_samples // 2]["pred_distribution"].values
-        pred_sample_two = df.iloc[n_samples // 2 :]["pred_distribution"].values
+        pred_samples = df["pred_distribution"].values
+        pred_sample_one = pred_samples[: n_samples // 2]
+        pred_sample_two = pred_samples[n_samples // 2 :]
         if len(pred_sample_two) != len(pred_sample_one):
             # If an odd number of samples, drop the last one
             pred_sample_two = pred_sample_two[:-1]
 
-        crps = np.mean(np.abs(pred_sample_one - response)) - 0.5 * np.mean(np.abs(pred_sample_one - pred_sample_two))
+        crps = np.mean(np.abs(pred_samples - response)) - 0.5 * np.mean(np.abs(pred_sample_one - pred_sample_two))
 
     response_bounded = max(response, 1e-5)
     return 100 * crps / response_bounded
@@ -91,6 +92,7 @@ def calculate_crps(response_series: pd.Series, predicted_distribution: pd.DataFr
         response_series: A series of the actual sales values
         predicted_distribution: A dataframe containing a sample of the prediction distribution for each date.
             If there is only a single sample, the CRPS reduces to the mean absolute (percentage) error.
+        date_column: Name of the date index colume to merge inputs together.
 
     Returns:
         Scaled CRPS value as float

--- a/mmm_eval/metrics/threshold_constants.py
+++ b/mmm_eval/metrics/threshold_constants.py
@@ -9,6 +9,7 @@ class AccuracyThresholdConstants:
     MAPE = 15.0
     SMAPE = 15.0
     R_SQUARED = 0.8
+    CRPS = 15.0
 
 
 class CrossValidationThresholdConstants:
@@ -19,6 +20,7 @@ class CrossValidationThresholdConstants:
     MEAN_SMAPE = 15.0
     STD_SMAPE = 5.0
     MEAN_R_SQUARED = 0.8
+    MEAN_CRPS = 15.0
 
 
 class RefreshStabilityThresholdConstants:

--- a/mmm_eval/utils/validation_utils.py
+++ b/mmm_eval/utils/validation_utils.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+
+
+def distribution_to_dataframe(distribution: np.ndarray, index: pd.Index) -> pd.DataFrame:
+    """Generate a DataFrame from a distribution array.
+
+    Args:
+        distribution (np.ndarray): The distribution array, shape (samples x time)
+        index (pd.Index): The index of the actual values, shape (time,)
+
+    Returns:
+        A DataFrame, with sample*time number of rows.
+
+    """
+    name = index.name
+    distribution_df = (
+        pd.DataFrame(distribution, columns=index)
+        .reset_index(names="sample_index")
+        .melt(id_vars="sample_index", var_name=name, value_name="pred_distribution")
+    )
+    distribution_df[name] = pd.to_datetime(distribution_df[name])
+    return distribution_df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mmm-eval"
-version = "0.12.0"
+version = "0.13.0"
 description = "Open-source evaluation of marketing mix model (MMM) performance"
 authors = ["Joseph Kang <joseph.kang@mutinex.co>",
            "Phil Clark <phil.clark@mutinex.co>",

--- a/tests/test_accuracy_functions.py
+++ b/tests/test_accuracy_functions.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.metrics import mean_absolute_percentage_error
 
 from mmm_eval.metrics.accuracy_functions import (
     calculate_absolute_percentage_change,
@@ -15,6 +16,7 @@ from mmm_eval.metrics.metric_models import (
     AccuracyMetricNames,
     AccuracyMetricResults,
     calculate_smape,
+    crps_one_date,
 )
 
 
@@ -61,9 +63,9 @@ class TestCrossValidationFoldCalculations:
     def test_calculate_mean_for_singular_values_across_cross_validation_folds(self):
         """Test mean calculation across folds for single values."""
         fold_metrics = [
-            AccuracyMetricResults(mape=0.1, smape=0.095, r_squared=0.8),
-            AccuracyMetricResults(mape=0.2, smape=0.105, r_squared=0.7),
-            AccuracyMetricResults(mape=0.3, smape=0.115, r_squared=0.9),
+            AccuracyMetricResults(mape=0.1, smape=0.095, r_squared=0.8, crps=0.1),
+            AccuracyMetricResults(mape=0.2, smape=0.105, r_squared=0.7, crps=0.2),
+            AccuracyMetricResults(mape=0.3, smape=0.115, r_squared=0.9, crps=0.3),
         ]
 
         result = calculate_mean_for_singular_values_across_cross_validation_folds(
@@ -77,9 +79,9 @@ class TestCrossValidationFoldCalculations:
     def test_calculate_std_for_singular_values_across_cross_validation_folds(self):
         """Test standard deviation calculation across folds for single values."""
         fold_metrics = [
-            AccuracyMetricResults(mape=0.1, smape=0.095, r_squared=0.8),
-            AccuracyMetricResults(mape=0.2, smape=0.105, r_squared=0.7),
-            AccuracyMetricResults(mape=0.3, smape=0.115, r_squared=0.9),
+            AccuracyMetricResults(mape=0.1, smape=0.095, r_squared=0.8, crps=0.1),
+            AccuracyMetricResults(mape=0.2, smape=0.105, r_squared=0.7, crps=0.2),
+            AccuracyMetricResults(mape=0.3, smape=0.115, r_squared=0.9, crps=0.3),
         ]
 
         result = calculate_std_for_singular_values_across_cross_validation_folds(fold_metrics, AccuracyMetricNames.MAPE)
@@ -270,3 +272,20 @@ class TestCalculateSMAPE:
 
         with pytest.raises(ValueError, match="Actual and predicted series must be free of NaN values"):
             calculate_smape(actual, predicted)
+
+
+class TestCalculateCRPS:
+    """Test cases for CRPS."""
+
+    def test_crps(self):
+        """Test crps for one value."""
+        input_df = pd.DataFrame({"response": [1.0, 1.0, 1.0, 1.0], "pred_distribution": [0.5, 1.5, 1.5, 2.0]})
+        crps = crps_one_date(input_df)
+
+        assert crps == 100 * (0.25 * (0.5 + 0.5 + 0.5 + 1.0) - 0.25 * (1.0 + 0.5)) / 1.0
+
+    def test_crps_point_estimate(self):
+        """Test crps reduces to mape for a single value."""
+        input_df = pd.DataFrame({"response": [1.0], "pred_distribution": [2.0]})
+        crps = crps_one_date(input_df)
+        assert crps == 100 * mean_absolute_percentage_error(np.array([1.0]), np.array([2.0]))

--- a/tests/test_adapters/test_meridian.py
+++ b/tests/test_adapters/test_meridian.py
@@ -684,11 +684,13 @@ class TestMeridianAdapter:
         preds_tensor = np.ones((2, 2, 5)) * 10
         mock_analyzer_instance.expected_outcome.return_value = preds_tensor
         # No holdout mask
-        assert np.allclose(adapter.predict(), np.mean(preds_tensor, axis=(0, 1)))
+        predictions, _ = adapter.predict()
+        assert np.allclose(predictions, np.mean(preds_tensor, axis=(0, 1)))
         # With holdout mask
         adapter.holdout_mask = np.array([False, True, True, False, True])
         masked = np.mean(preds_tensor, axis=(0, 1))[adapter.holdout_mask]
-        assert np.allclose(adapter.predict(), masked)
+        predictions, _ = adapter.predict()
+        assert np.allclose(predictions, masked)
 
     def test_predict_raises_if_not_fitted(self):
         """Test that predict raises RuntimeError if model is not fitted."""
@@ -703,8 +705,8 @@ class TestMeridianAdapter:
         adapter = MeridianAdapter(self.config)
         train = self.df.iloc[:3]
         test = self.df.iloc[3:]
-        mock_predict.return_value = np.array([1, 2, 35])
-        result = adapter.fit_and_predict(train, test)
+        mock_predict.return_value = np.array([1, 2, 35]), np.array([1, 2, 35])
+        result, _ = adapter.fit_and_predict(train, test)
         mock_fit.assert_called_once()
         mock_predict.assert_called_once()
         assert np.all(result == np.array([1, 2, 35]))
@@ -714,8 +716,8 @@ class TestMeridianAdapter:
     def test_fit_and_predict_in_sample_calls_fit_and_predict_in_sample(self, mock_predict_on_all_data, mock_fit):
         """Test that fit_and_predict_in_sample calls fit and _predict_on_all_data methods."""
         adapter = MeridianAdapter(self.config)
-        mock_predict_on_all_data.return_value = np.array([1, 2, 3, 4, 5])
-        result = adapter.fit_and_predict_in_sample(self.df)
+        mock_predict_on_all_data.return_value = np.array([1, 2, 3, 4, 5]), np.array([1, 2, 3, 4, 5])
+        result, _ = adapter.fit_and_predict_in_sample(self.df)
         mock_fit.assert_called_once_with(self.df)
         mock_predict_on_all_data.assert_called_once()
         assert np.all(result == np.array([1, 2, 3, 4, 5]))

--- a/tests/test_adapters/test_pymc.py
+++ b/tests/test_adapters/test_pymc.py
@@ -248,7 +248,7 @@ def test_predict_method_real_pymc(valid_pymc_config, realistic_test_data):
     adapter.fit(data)
 
     # Test prediction
-    result = adapter.predict(data)
+    result, _ = adapter.predict(data)
 
     # Verify prediction results
     assert isinstance(result, np.ndarray)
@@ -309,7 +309,7 @@ def test_adapter_integration_real_pymc(valid_pymc_config, realistic_test_data):
     adapter.fit(data)
     assert adapter.is_fitted is True
 
-    predictions = adapter.predict(data)
+    predictions, _ = adapter.predict(data)
     assert isinstance(predictions, np.ndarray)
     assert len(predictions) == len(data)
 
@@ -335,12 +335,13 @@ def test_fit_and_predict_in_sample_method_real_pymc(valid_pymc_config, realistic
     data = realistic_test_data
 
     # Test fit_and_predict_in_sample
-    result = adapter.fit_and_predict_in_sample(data)
+    result, dist = adapter.fit_and_predict_in_sample(data)
 
     # Verify prediction results
     assert isinstance(result, np.ndarray)
     assert len(result) == len(data)
     assert not np.all(np.isnan(result))  # Should have some non-NaN predictions
+    assert np.allclose(dist.mean(0), result)
 
     # Verify the model was fitted
     assert adapter.is_fitted is True
@@ -622,7 +623,7 @@ def test_fit_resets_to_original_channels_on_subsequent_fits(valid_pymc_config, r
     assert adapter.model_kwargs["channel_columns"] == ["channel_2"]
 
     # Test prediction with the fitted model (should work with reduced channels)
-    predictions = adapter.predict(data_with_zero_spend)
+    predictions, _ = adapter.predict(data_with_zero_spend)
     assert isinstance(predictions, np.ndarray)
     assert len(predictions) == len(data_with_zero_spend)
 
@@ -648,7 +649,7 @@ def test_fit_resets_to_original_channels_on_subsequent_fits(valid_pymc_config, r
     assert adapter.model_kwargs["channel_columns"] == ["channel_1", "channel_2"]
 
     # Test prediction with the re-fitted model (should work with all channels)
-    predictions = adapter.predict(data_without_zero_spend)
+    predictions, _ = adapter.predict(data_without_zero_spend)
     assert isinstance(predictions, np.ndarray)
     assert len(predictions) == len(data_without_zero_spend)
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -127,13 +127,13 @@ def test_cli_e2e_meridian(tmp_path):
             # Return predictions matching the number of unique dates in test data
             # The data pipeline renames 'conversions' to 'response', so we need to use the processed column name
             unique_dates = test["date"].nunique()
-            return np.ones(unique_dates) * 100.0
+            return np.ones(unique_dates) * 100.0, np.ones((unique_dates, unique_dates)) * 100.0
 
         def fit_and_predict_in_sample(self, data):
             # Return predictions matching the number of unique dates in full data
             # The data pipeline renames 'conversions' to 'response'
             unique_dates = data["date"].nunique()
-            return np.ones(unique_dates) * 100.0
+            return np.ones(unique_dates) * 100.0, np.ones((unique_dates, unique_dates)) * 100.0
 
         def get_channel_roi(self, start_date=None, end_date=None):
             # Dynamically create ROI results based on current media channels

--- a/tests/test_metric_models.py
+++ b/tests/test_metric_models.py
@@ -22,29 +22,31 @@ class TestAccuracyMetricResults:
 
     def test_accuracy_metric_threshold_checking_good_metrics(self):
         """Test accuracy metric threshold checking with good metrics."""
-        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85, crps=14.0)
 
         # Test individual metric threshold checking
         assert results._check_metric_threshold(AccuracyMetricNames.MAPE.value, 10.0) is True
         assert results._check_metric_threshold(AccuracyMetricNames.R_SQUARED.value, 0.85) is True
+        assert results._check_metric_threshold(AccuracyMetricNames.CRPS.value, 14.0) is True
 
     def test_accuracy_metric_threshold_checking_bad_metrics(self):
         """Test accuracy metric threshold checking with bad metrics."""
-        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85, crps=16.0)
 
         # Test individual metric threshold checking
         assert results._check_metric_threshold(AccuracyMetricNames.MAPE.value, 20.0) is False
         assert results._check_metric_threshold(AccuracyMetricNames.R_SQUARED.value, 0.75) is False
+        assert results._check_metric_threshold(AccuracyMetricNames.CRPS.value, 16.0) is False
 
     def test_accuracy_metric_dataframe_output(self):
         """Test accuracy metric results DataFrame output."""
-        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85, crps=15.0)
         df = results.to_df()
 
         # Check DataFrame structure
         expected_columns = TestResultDFAttributes.to_list()
         assert list(df.columns) == expected_columns
-        assert len(df) == 3
+        assert len(df) == 4
 
         # Check metric values
         mape_row = df[df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == AccuracyMetricNames.MAPE.value].iloc[0]
@@ -59,7 +61,7 @@ class TestAccuracyMetricResults:
 
     def test_accuracy_metric_invalid_metric_name(self):
         """Test accuracy metric with invalid metric name."""
-        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85)
+        results = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.85, crps=14.0)
 
         with pytest.raises(InvalidMetricNameException):
             results._check_metric_threshold("invalid_metric", 0.1)
@@ -71,7 +73,7 @@ class TestCrossValidationMetricResults:
     def test_cross_validation_metric_threshold_checking_good_metrics(self):
         """Test cross-validation metric threshold checking with good metrics."""
         results = CrossValidationMetricResults(
-            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85
+            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85, mean_crps=14.0
         )
 
         # Test individual metric threshold checking
@@ -82,7 +84,7 @@ class TestCrossValidationMetricResults:
     def test_cross_validation_metric_threshold_checking_bad_metrics(self):
         """Test cross-validation metric threshold checking with bad metrics."""
         results = CrossValidationMetricResults(
-            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85
+            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85, mean_crps=14.0
         )
 
         # Test individual metric threshold checking
@@ -92,14 +94,14 @@ class TestCrossValidationMetricResults:
     def test_cross_validation_metric_dataframe_output(self):
         """Test cross-validation metric results DataFrame output."""
         results = CrossValidationMetricResults(
-            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85
+            mean_mape=12.0, std_mape=2.0, mean_smape=11.5, std_smape=1.5, mean_r_squared=0.85, mean_crps=14.0
         )
         df = results.to_df()
 
         # Check DataFrame structure
         expected_columns = TestResultDFAttributes.to_list()
         assert list(df.columns) == expected_columns
-        assert len(df) == 5
+        assert len(df) == 6
 
         # Check metric values
         mean_mape_row = df[df[TestResultDFAttributes.GENERAL_METRIC_NAME.value] == "mean_mape"].iloc[0]

--- a/tests/test_validation_test_results.py
+++ b/tests/test_validation_test_results.py
@@ -24,7 +24,7 @@ class TestValidationTestResult:
 
     def test_test_result_creation_and_to_df(self):
         """Test TestResult creation and to_df conversion."""
-        test_scores = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8)
+        test_scores = AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8, crps=10.0)
         metric_names = AccuracyMetricNames.to_list()
 
         result = ValidationTestResult(
@@ -106,7 +106,7 @@ class TestValidationResults:
         accuracy_result = ValidationTestResult(
             test_name=ValidationTestNames.HOLDOUT_ACCURACY,
             metric_names=AccuracyMetricNames.to_list(),
-            test_scores=AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8),
+            test_scores=AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8, crps=15.0),
         )
 
         # Create stability result with new field names
@@ -140,7 +140,7 @@ class TestValidationResults:
         accuracy_result = ValidationTestResult(
             test_name=ValidationTestNames.HOLDOUT_ACCURACY,
             metric_names=AccuracyMetricNames.to_list(),
-            test_scores=AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8),
+            test_scores=AccuracyMetricResults(mape=10.0, smape=9.5, r_squared=0.8, crps=10.0),
         )
 
         test_results = {ValidationTestNames.HOLDOUT_ACCURACY: accuracy_result}
@@ -152,7 +152,7 @@ class TestValidationResults:
         assert ValidationTestAttributeNames.TEST_NAME.value in result_df.columns
         assert ValidationTestAttributeNames.TIMESTAMP.value in result_df.columns
         # Should have 3 rows: one for each accuracy metric (mape, smape, and r_squared)
-        assert len(result_df) == 3
+        assert len(result_df) == 4
 
     def test_validation_result_to_df_with_series_metrics(self):
         """Test ValidationResults to_df conversion with Series-based metrics."""


### PR DESCRIPTION
Continuous Ranked Probability Score (CRPS) is a proper scoring rule to evaluate the prediction of a probability distribution.
It rewards distributions that:
- Have a large amount of density close to the actual value
- Are not spread too wide
- Hits the X% percentile X% of the time

This implements a scaled version of CRPS in the mmm-eval alongside the existing accuracy metrics (MAPE, R2, etc.).
The scaling factor makes this a generalisation of MAPE, so the output value can be consistently compared against a threshold regardless of what kinds of values the data has. 
- Regular CRPS is a probabilitstic version of MAE, so the value depends on the magnitude of sales.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces scaled CRPS accuracy metric and plumbs posterior predictive distributions from adapters into validation to compute it, with docs, thresholds, tests, and version updated.
> 
> - **Metrics**:
>   - Add scaled `CRPS` computation (`crps_one_date`, `calculate_crps`) and include in `AccuracyMetricNames/Results` and `CrossValidationMetricNames/Results` (`mean_crps`).
>   - Update thresholds to include `CRPS`/`MEAN_CRPS`.
> - **Adapters**:
>   - Change `BaseAdapter` `predict/fit_and_predict/fit_and_predict_in_sample` to return `(posterior_mean, posterior_distribution)`.
>   - Meridian: return posterior mean and flattened distribution; apply holdout mask to both.
>   - PyMC: use `predict_posterior(combined=True)`; return mean and distribution (transposed) tuples.
> - **Validation**:
>   - Accuracy and CV tests now pass predictive distributions to compute `CRPS`.
>   - Add `distribution_to_dataframe` utility to reshape distributions for metric calc.
> - **Docs**:
>   - Add CRPS to metrics/tests guides, definitions, interpretation, and benchmarks.
> - **Tests**:
>   - Update unit/integration/E2E tests for new adapter return types and CRPS calculations.
> - **Release**:
>   - Bump version to `0.13.0`; update `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9058b5af4c657caf03cfb157646f60f8c2714fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->